### PR TITLE
manifest: properly mount .local/share/flatpak

### DIFF
--- a/com.endlessm.EknServices.json.in
+++ b/com.endlessm.EknServices.json.in
@@ -6,6 +6,7 @@
     "finish-args": [
         "--filesystem=/var/lib/flatpak:ro",
         "--filesystem=/var/endless-extra/flatpak:ro",
+        "--filesystem=~/.local/share/flatpak:ro",
         "--filesystem=~/.local/share",
         "--env=EKN_SUBSCRIPTIONS_DIR=.local/share/com.endlessm.subscriptions",
         "--share=network",


### PR DESCRIPTION
We need it to read content from user installed (not system wide)
knowledge apps
https://phabricator.endlessm.com/T15847