### PR TITLE
provider: Add support for Grand Central queries too

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -39,12 +39,12 @@ search-provider/eks-search-provider-dbus.h search-provider/eks-search-provider-d
 	--generate-c-code search-provider/eks-search-provider-dbus \
 	$<
 
-search-provider/eks-grand-central-provider-dbus.h search-provider/eks-grand-central-provider-dbus.c: search-provider/eks-grand-central-provider-dbus.xml Makefile.am
+search-provider/eks-discovery-feed-provider-dbus.h search-provider/eks-discovery-feed-provider-dbus.c: search-provider/eks-discovery-feed-provider-dbus.xml Makefile.am
 	$(AM_V_GEN) $(MKDIR_P) $(@D) && \
 	$(GDBUS_CODEGEN) \
 	--interface-prefix=com.endlessm. \
 	--c-namespace Eks \
-	--generate-c-code search-provider/eks-grand-central-provider-dbus \
+	--generate-c-code search-provider/eks-discovery-feed-provider-dbus \
 	$<
 
 search-provider/eks-knowledge-app-dbus.h search-provider/eks-knowledge-app-dbus.c: search-provider/eks-knowledge-app-dbus.xml Makefile.am
@@ -57,15 +57,15 @@ search-provider/eks-knowledge-app-dbus.h search-provider/eks-knowledge-app-dbus.
 
 EXTRA_DIST += \
 	search-provider/eks-search-provider-dbus.xml \
-	search-provider/eks-grand-central-provider-dbus.xml \
+	search-provider/eks-discovery-feed-provider-dbus.xml \
 	search-provider/eks-knowledge-app-dbus.xml \
 	$(NULL)
 
 BUILT_SOURCES = \
 	search-provider/eks-search-provider-dbus.h \
 	search-provider/eks-search-provider-dbus.c \
-	search-provider/eks-grand-central-provider-dbus.h \
-	search-provider/eks-grand-central-provider-dbus.c \
+	search-provider/eks-discovery-feed-provider-dbus.h \
+	search-provider/eks-discovery-feed-provider-dbus.c \
 	search-provider/eks-knowledge-app-dbus.h \
 	search-provider/eks-knowledge-app-dbus.c \
 	$(NULL)
@@ -78,12 +78,12 @@ eks_search_provider_v1_SOURCES = \
 	search-provider/eks-search-main.c \
 	search-provider/eks-search-provider-dbus.c \
 	search-provider/eks-search-provider-dbus.h \
-	search-provider/eks-grand-central-provider-dbus.c \
-	search-provider/eks-grand-central-provider-dbus.h \
+	search-provider/eks-discovery-feed-provider-dbus.c \
+	search-provider/eks-discovery-feed-provider-dbus.h \
 	search-provider/eks-search-provider.c \
 	search-provider/eks-search-provider.h \
-	search-provider/eks-grand-central-provider.c \
-	search-provider/eks-grand-central-provider.h \
+	search-provider/eks-discovery-feed-provider.c \
+	search-provider/eks-discovery-feed-provider.h \
 	search-provider/eks-subtree-dispatcher.c \
 	search-provider/eks-subtree-dispatcher.h \
 	$(NULL)

--- a/Makefile.am
+++ b/Makefile.am
@@ -39,6 +39,14 @@ search-provider/eks-search-provider-dbus.h search-provider/eks-search-provider-d
 	--generate-c-code search-provider/eks-search-provider-dbus \
 	$<
 
+search-provider/eks-grand-central-provider-dbus.h search-provider/eks-grand-central-provider-dbus.c: search-provider/eks-grand-central-provider-dbus.xml Makefile.am
+	$(AM_V_GEN) $(MKDIR_P) $(@D) && \
+	$(GDBUS_CODEGEN) \
+	--interface-prefix=com.endlessm. \
+	--c-namespace Eks \
+	--generate-c-code search-provider/eks-grand-central-provider-dbus \
+	$<
+
 search-provider/eks-knowledge-app-dbus.h search-provider/eks-knowledge-app-dbus.c: search-provider/eks-knowledge-app-dbus.xml Makefile.am
 	$(AM_V_GEN) $(MKDIR_P) $(@D) && \
 	$(GDBUS_CODEGEN) \
@@ -49,12 +57,15 @@ search-provider/eks-knowledge-app-dbus.h search-provider/eks-knowledge-app-dbus.
 
 EXTRA_DIST += \
 	search-provider/eks-search-provider-dbus.xml \
+	search-provider/eks-grand-central-provider-dbus.xml \
 	search-provider/eks-knowledge-app-dbus.xml \
 	$(NULL)
 
 BUILT_SOURCES = \
 	search-provider/eks-search-provider-dbus.h \
 	search-provider/eks-search-provider-dbus.c \
+	search-provider/eks-grand-central-provider-dbus.h \
+	search-provider/eks-grand-central-provider-dbus.c \
 	search-provider/eks-knowledge-app-dbus.h \
 	search-provider/eks-knowledge-app-dbus.c \
 	$(NULL)
@@ -67,8 +78,12 @@ eks_search_provider_v1_SOURCES = \
 	search-provider/eks-search-main.c \
 	search-provider/eks-search-provider-dbus.c \
 	search-provider/eks-search-provider-dbus.h \
+	search-provider/eks-grand-central-provider-dbus.c \
+	search-provider/eks-grand-central-provider-dbus.h \
 	search-provider/eks-search-provider.c \
 	search-provider/eks-search-provider.h \
+	search-provider/eks-grand-central-provider.c \
+	search-provider/eks-grand-central-provider.h \
 	search-provider/eks-subtree-dispatcher.c \
 	search-provider/eks-subtree-dispatcher.h \
 	$(NULL)

--- a/search-provider/eks-discovery-feed-provider-dbus.xml
+++ b/search-provider/eks-discovery-feed-provider-dbus.xml
@@ -1,0 +1,25 @@
+<!DOCTYPE node PUBLIC
+"-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+
+<!--
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General
+ Public License along with this library; if not, see <http://www.gnu.org/licenses/>.
+-->
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <interface name="com.endlessm.DiscoveryFeedContent">
+    <method name="ArticleCardDescriptions">
+      <arg type="aa{ss}" name="Results" direction="out" />
+    </method>
+  </interface>
+</node>

--- a/search-provider/eks-discovery-feed-provider.c
+++ b/search-provider/eks-discovery-feed-provider.c
@@ -1,0 +1,285 @@
+/* Copyright 2016 Endless Mobile, Inc. */
+
+#include "eks-discovery-feed-provider.h"
+
+#include "eks-knowledge-app-dbus.h"
+#include "eks-discovery-feed-provider-dbus.h"
+
+#include <eos-knowledge-content.h>
+#include <string.h>
+
+struct _EksDiscoveryFeedDatabaseContentProvider
+{
+  GObject parent_instance;
+
+  gchar *application_id;
+  EksDiscoveryFeedContent *skeleton;
+  EksDiscoveryFeedContent *app_proxy;
+  GCancellable *cancellable;
+};
+
+G_DEFINE_TYPE (EksDiscoveryFeedDatabaseContentProvider,
+               eks_discovery_feed_database_content_provider,
+               G_TYPE_OBJECT)
+
+enum {
+  PROP_0,
+  PROP_APPLICATION_ID,
+  PROP_SKELETON,
+  NPROPS
+};
+
+static GParamSpec *eks_discovery_feed_database_content_provider_props [NPROPS] = { NULL, };
+
+static void
+eks_discovery_feed_database_content_provider_get_property (GObject    *object,
+                                                           guint       prop_id,
+                                                           GValue     *value,
+                                                           GParamSpec *pspec)
+{
+  EksDiscoveryFeedDatabaseContentProvider *self = EKS_DISCOVERY_FEED_DATABASE_CONTENT_PROVIDER (object);
+
+  switch (prop_id)
+    {
+    case PROP_APPLICATION_ID:
+      g_value_set_string (value, self->application_id);
+      break;
+
+    case PROP_SKELETON:
+      g_value_set_object (value, self->skeleton);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+eks_discovery_feed_database_content_provider_set_property (GObject      *object,
+                                                           guint         prop_id,
+                                                           const GValue *value,
+                                                           GParamSpec   *pspec)
+{
+  EksDiscoveryFeedDatabaseContentProvider *self = EKS_DISCOVERY_FEED_DATABASE_CONTENT_PROVIDER (object);
+
+  switch (prop_id)
+    {
+    case PROP_APPLICATION_ID:
+      g_clear_pointer (&self->application_id, g_free);
+      self->application_id = g_value_dup_string (value);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+eks_discovery_feed_database_content_provider_finalize (GObject *object)
+{
+  EksDiscoveryFeedDatabaseContentProvider *self = EKS_DISCOVERY_FEED_DATABASE_CONTENT_PROVIDER (object);
+
+  g_clear_pointer (&self->application_id, g_free);
+  g_clear_object (&self->skeleton);
+  g_clear_object (&self->app_proxy);
+  g_clear_object (&self->cancellable);
+
+  G_OBJECT_CLASS (eks_discovery_feed_database_content_provider_parent_class)->finalize (object);
+}
+
+static void
+eks_discovery_feed_database_content_provider_class_init (EksDiscoveryFeedDatabaseContentProviderClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->get_property = eks_discovery_feed_database_content_provider_get_property;
+  object_class->set_property = eks_discovery_feed_database_content_provider_set_property;
+  object_class->finalize = eks_discovery_feed_database_content_provider_finalize;
+
+  eks_discovery_feed_database_content_provider_props[PROP_APPLICATION_ID] =
+    g_param_spec_string ("application-id", "Application Id", "Application Id",
+      "", G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
+
+  eks_discovery_feed_database_content_provider_props[PROP_SKELETON] =
+    g_param_spec_object ("skeleton", "Skeleton", "Skeleton",
+      G_TYPE_DBUS_INTERFACE_SKELETON, G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
+
+  g_object_class_install_properties (object_class,
+                                     NPROPS,
+                                     eks_discovery_feed_database_content_provider_props);
+}
+
+static  gchar *
+object_path_from_app_id (const gchar *application_id)
+{
+  g_autoptr(GRegex) dot_regex = g_regex_new ("\\.", 0, 0, NULL);
+  g_autofree gchar *replaced = g_regex_replace (dot_regex, application_id, -1, 0, "/", 0, NULL);
+  return g_strconcat ("/", replaced, NULL);
+}
+
+static gboolean
+ensure_app_proxy (EksDiscoveryFeedDatabaseContentProvider *self)
+{
+  if (self->app_proxy != NULL)
+    return TRUE;
+
+  g_autofree gchar *object_path = object_path_from_app_id (self->application_id);
+  GError *error = NULL;
+  self->app_proxy = eks_discovery_feed_content_proxy_new_for_bus_sync (G_BUS_TYPE_SESSION,
+                                                                       G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START_AT_CONSTRUCTION |
+                                                                       G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
+                                                                       self->application_id,
+                                                                       object_path,
+                                                                       NULL,
+                                                                       &error);
+  if (error != NULL)
+    {
+      g_warning ("Error initializing dbus proxy: %s\n", error->message);
+      g_clear_error (&error);
+      return FALSE;
+    }
+  return TRUE;
+}
+
+typedef struct {
+  GDBusMethodInvocation *invocation;
+  EksDiscoveryFeedDatabaseContentProvider  *provider;
+} DiscoveryFeedQueryState;
+
+static DiscoveryFeedQueryState *
+discovery_feed_query_state_new (GDBusMethodInvocation                  *invocation,
+                                EksDiscoveryFeedDatabaseContentProvider *provider)
+{
+  DiscoveryFeedQueryState *state = g_slice_new0 (DiscoveryFeedQueryState);
+  state->invocation = g_object_ref (invocation);
+  state->provider = provider;
+
+  return state;
+}
+
+static void
+discovery_feed_query_state_free (DiscoveryFeedQueryState *state)
+{
+  g_object_unref (state->invocation);
+  g_slice_free (DiscoveryFeedQueryState, state);
+}
+
+static inline gchar *
+underscorify (const gchar *string)
+{
+  gchar *underscored = strdup (string);
+  gchar *c = underscored;
+  do
+    {
+      if (*c == '-')
+        *c = '_';
+    }
+  while (*c++);
+
+  return underscored;
+}
+
+static void
+add_key_value_pair_from_model_to_variant (EkncContentObjectModel *model,
+                                          GVariantBuilder        *builder,
+                                          const char             *key)
+{
+  g_variant_builder_open (builder, G_VARIANT_TYPE ("{ss}"));
+  g_autofree gchar *value = NULL;
+  g_autofree gchar *underscore_key = underscorify (key);
+  g_object_get (model, key, &value, NULL);
+  g_variant_builder_add (builder, "s", underscore_key);
+  g_variant_builder_add (builder, "s", value);
+  g_variant_builder_close (builder);
+}
+
+static void
+article_card_descriptions_cb (GObject *source,
+                              GAsyncResult *result,
+                              gpointer user_data)
+{
+  EkncEngine *engine = EKNC_ENGINE (source);
+  DiscoveryFeedQueryState *state = user_data;
+
+  g_application_release (g_application_get_default ());
+
+  GError *error = NULL;
+  g_autoptr(EkncQueryResults) results = NULL;
+  if (!(results = eknc_engine_query_finish (engine, result, &error)))
+    {
+      g_dbus_method_invocation_return_gerror (state->invocation, error);
+      discovery_feed_query_state_free (state);
+      return;
+    }
+
+  GSList *models = eknc_query_results_get_models (results);
+
+  GVariantBuilder builder;
+  g_variant_builder_init (&builder, G_VARIANT_TYPE ("aa{ss}"));
+  for (GSList *l = models; l; l = l->next)
+    {
+      /* Start building up object */
+      g_variant_builder_open (&builder, G_VARIANT_TYPE ("a{ss}"));
+
+      EkncContentObjectModel *model = l->data;
+
+      /* Add key-value pair for title */
+      add_key_value_pair_from_model_to_variant (model, &builder, "title");
+      add_key_value_pair_from_model_to_variant (model, &builder, "synopsis");
+      add_key_value_pair_from_model_to_variant (model, &builder, "last-modified-date");
+      add_key_value_pair_from_model_to_variant (model, &builder, "thumbnail-uri");
+      add_key_value_pair_from_model_to_variant (model, &builder, "ekn-id");
+
+      /* Stop building object */
+      g_variant_builder_close (&builder);
+    }
+  g_dbus_method_invocation_return_value (state->invocation,
+                                         g_variant_new ("(aa{ss})", &builder));
+  discovery_feed_query_state_free (state);
+}
+
+static gboolean
+handle_article_card_descriptions (EksDiscoveryFeedDatabaseContentProvider *skeleton,
+                                  GDBusMethodInvocation                  *invocation,
+                                  gpointer                                user_data)
+{
+    EksDiscoveryFeedDatabaseContentProvider *self = (EksDiscoveryFeedDatabaseContentProvider *) user_data;
+
+    if (!ensure_app_proxy (self))
+      return TRUE;
+
+    EkncEngine *engine = eknc_engine_get_default ();
+
+    /* Build up tags_match_any */
+    GVariantBuilder tags_match_any_builder;
+    g_variant_builder_init (&tags_match_any_builder, G_VARIANT_TYPE ("as"));
+    g_variant_builder_add (&tags_match_any_builder, "s", "EknArticleObject");
+    GVariant *tags_match_any = g_variant_builder_end (&tags_match_any_builder);
+
+    /* Create query and run it */
+    g_autoptr(EkncQueryObject) query = g_object_new (EKNC_TYPE_QUERY_OBJECT,
+                                                     "tags-match-any", tags_match_any,
+                                                     "limit", 5,
+                                                     "app-id", self->application_id,
+                                                     NULL);
+
+    /* Hold the application so that it doesn't go away whilst we're handling
+     * the query */
+    g_application_hold (g_application_get_default ());
+
+    eknc_engine_query (engine,
+                       query,
+                       self->cancellable,
+                       article_card_descriptions_cb,
+                       discovery_feed_query_state_new (invocation, self));
+
+    return TRUE;
+}
+                       
+static void
+eks_discovery_feed_database_content_provider_init (EksDiscoveryFeedDatabaseContentProvider *self)
+{
+  self->skeleton = eks_discovery_feed_content_skeleton_new ();
+  g_signal_connect (self->skeleton, "handle-article-card-descriptions",
+                    G_CALLBACK (handle_article_card_descriptions), self);
+}

--- a/search-provider/eks-discovery-feed-provider.h
+++ b/search-provider/eks-discovery-feed-provider.h
@@ -1,0 +1,12 @@
+/* Copyright 2016 Endless Mobile, Inc. */
+
+#pragma once
+
+#include <gio/gio.h>
+
+G_BEGIN_DECLS
+
+#define EKS_TYPE_DISCOVERY_FEED_DATABASE_CONTENT_PROVIDER eks_discovery_feed_database_content_provider_get_type ()
+G_DECLARE_FINAL_TYPE (EksDiscoveryFeedDatabaseContentProvider, eks_discovery_feed_database_content_provider, EKS, DISCOVERY_FEED_DATABASE_CONTENT_PROVIDER, GObject)
+
+G_END_DECLS

--- a/search-provider/eks-search-app.c
+++ b/search-provider/eks-search-app.c
@@ -2,6 +2,8 @@
 
 #include "eks-search-app.h"
 
+#include "eks-grand-central-provider-dbus.h"
+#include "eks-grand-central-provider.h"
 #include "eks-search-provider.h"
 #include "eks-search-provider-dbus.h"
 #include "eks-subtree-dispatcher.h"
@@ -25,6 +27,8 @@ struct _EksSearchApp
   EksSubtreeDispatcher *dispatcher;
   // Hash table with app id string keys, EksSearchProvider values
   GHashTable *app_search_providers;
+  // Hash table with app id string keys, EksGrandCentralContentProvider values
+  GHashTable *grand_central_content_providers;
 };
 
 G_DEFINE_TYPE (EksSearchApp,
@@ -38,15 +42,16 @@ eks_search_app_finalize (GObject *object)
 
   g_clear_object (&self->dispatcher);
   g_clear_pointer (&self->app_search_providers, g_hash_table_unref);
+  g_clear_pointer (&self->grand_central_content_providers, g_hash_table_unref);
 
   G_OBJECT_CLASS (eks_search_app_parent_class)->finalize (object);
 }
 
 static gboolean
-eks_search_app_register (GApplication *application,
+eks_search_app_register (GApplication    *application,
                          GDBusConnection *connection,
-                         const gchar *object_path,
-                         GError **error)
+                         const gchar     *object_path,
+                         GError          **error)
 {
   EksSearchApp *self = EKS_SEARCH_APP (application);
 
@@ -55,9 +60,9 @@ eks_search_app_register (GApplication *application,
 }
 
 static void
-eks_search_app_unregister (GApplication *application,
+eks_search_app_unregister (GApplication    *application,
                            GDBusConnection *connection,
-                           const gchar *object_path)
+                           const gchar     *object_path)
 {
   EksSearchApp *self = EKS_SEARCH_APP (application);
 
@@ -137,19 +142,47 @@ bus_label_unescape (const gchar *f) {
   return r;
 }
 
+typedef struct {
+    GType create_type;
+    GHashTable *cache;
+} SubtreeObjectInfo;
+
+static void
+subtree_object_info_for_interface (EksSearchApp      *self,
+                                   const gchar       *interface,
+                                   SubtreeObjectInfo *info)
+{
+  if (g_strcmp0 (interface, "org.gnome.Shell.SearchProvider") == 0)
+    {
+      info->create_type = EKS_TYPE_SEARCH_PROVIDER;
+      info->cache = self->app_search_providers;
+    }
+  else if (g_strcmp0 (interface, "com.endlessm.GrandCentralContent") == 0)
+    {
+      info->create_type = EKS_TYPE_GRAND_CENTRAL_DATABASE_CONTENT_PROVIDER;
+      info->cache = self->grand_central_content_providers;
+    }
+  else
+    g_assert_not_reached();
+}
+
 static GDBusInterfaceSkeleton *
 dispatch_subtree (EksSubtreeDispatcher *dispatcher,
                   const gchar *subnode,
+                  const gchar *interface,
                   EksSearchApp *self)
 {
-  EksSearchProvider *provider = g_hash_table_lookup (self->app_search_providers, subnode);
+  SubtreeObjectInfo info;
+  subtree_object_info_for_interface (self, interface, &info);
+
+  GObject *provider = g_hash_table_lookup (info.cache, subnode);
   if (provider == NULL)
     {
       g_autofree gchar *app_id = bus_label_unescape (subnode);
-      provider = g_object_new (EKS_TYPE_SEARCH_PROVIDER,
+      provider = g_object_new (info.create_type,
                                "application-id", app_id,
                                NULL);
-      g_hash_table_insert (self->app_search_providers, g_strdup (subnode), provider);
+      g_hash_table_insert (info.cache, g_strdup (subnode), provider);
     }
 
   GDBusInterfaceSkeleton *skeleton;
@@ -157,13 +190,23 @@ dispatch_subtree (EksSubtreeDispatcher *dispatcher,
   return skeleton;
 }
 
+static GPtrArray *
+eks_search_app_node_interface_infos ()
+{
+  GPtrArray *ptr_array = g_ptr_array_new_full (2, (GDestroyNotify) g_dbus_interface_info_unref);
+  g_ptr_array_add (ptr_array, eks_search_provider2_interface_info ());
+  g_ptr_array_add (ptr_array, eks_grand_central_content_interface_info ());
+  return ptr_array;
+}
+
 static void
 eks_search_app_init (EksSearchApp *self)
 {
   self->dispatcher = g_object_new (EKS_TYPE_SUBTREE_DISPATCHER,
-                                   "interface-info", eks_search_provider2_interface_info (),
+                                   "interface-infos", eks_search_app_node_interface_infos (),
                                    NULL);
   self->app_search_providers = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
+  self->grand_central_content_providers = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
   g_signal_connect (self->dispatcher, "dispatch-subtree",
                     G_CALLBACK (dispatch_subtree), self);
 }

--- a/search-provider/eks-search-app.c
+++ b/search-provider/eks-search-app.c
@@ -2,8 +2,8 @@
 
 #include "eks-search-app.h"
 
-#include "eks-grand-central-provider-dbus.h"
-#include "eks-grand-central-provider.h"
+#include "eks-discovery-feed-provider-dbus.h"
+#include "eks-discovery-feed-provider.h"
 #include "eks-search-provider.h"
 #include "eks-search-provider-dbus.h"
 #include "eks-subtree-dispatcher.h"
@@ -27,8 +27,8 @@ struct _EksSearchApp
   EksSubtreeDispatcher *dispatcher;
   // Hash table with app id string keys, EksSearchProvider values
   GHashTable *app_search_providers;
-  // Hash table with app id string keys, EksGrandCentralContentProvider values
-  GHashTable *grand_central_content_providers;
+  // Hash table with app id string keys, EksDiscoveryFeedContentProvider values
+  GHashTable *discovery_feed_content_providers;
 };
 
 G_DEFINE_TYPE (EksSearchApp,
@@ -42,7 +42,7 @@ eks_search_app_finalize (GObject *object)
 
   g_clear_object (&self->dispatcher);
   g_clear_pointer (&self->app_search_providers, g_hash_table_unref);
-  g_clear_pointer (&self->grand_central_content_providers, g_hash_table_unref);
+  g_clear_pointer (&self->discovery_feed_content_providers, g_hash_table_unref);
 
   G_OBJECT_CLASS (eks_search_app_parent_class)->finalize (object);
 }
@@ -157,10 +157,10 @@ subtree_object_info_for_interface (EksSearchApp      *self,
       info->create_type = EKS_TYPE_SEARCH_PROVIDER;
       info->cache = self->app_search_providers;
     }
-  else if (g_strcmp0 (interface, "com.endlessm.GrandCentralContent") == 0)
+  else if (g_strcmp0 (interface, "com.endlessm.DiscoveryFeedContent") == 0)
     {
-      info->create_type = EKS_TYPE_GRAND_CENTRAL_DATABASE_CONTENT_PROVIDER;
-      info->cache = self->grand_central_content_providers;
+      info->create_type = EKS_TYPE_DISCOVERY_FEED_DATABASE_CONTENT_PROVIDER;
+      info->cache = self->discovery_feed_content_providers;
     }
   else
     g_assert_not_reached();
@@ -195,7 +195,7 @@ eks_search_app_node_interface_infos ()
 {
   GPtrArray *ptr_array = g_ptr_array_new_full (2, (GDestroyNotify) g_dbus_interface_info_unref);
   g_ptr_array_add (ptr_array, eks_search_provider2_interface_info ());
-  g_ptr_array_add (ptr_array, eks_grand_central_content_interface_info ());
+  g_ptr_array_add (ptr_array, eks_discovery_feed_content_interface_info ());
   return ptr_array;
 }
 
@@ -206,7 +206,7 @@ eks_search_app_init (EksSearchApp *self)
                                    "interface-infos", eks_search_app_node_interface_infos (),
                                    NULL);
   self->app_search_providers = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
-  self->grand_central_content_providers = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
+  self->discovery_feed_content_providers = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
   g_signal_connect (self->dispatcher, "dispatch-subtree",
                     G_CALLBACK (dispatch_subtree), self);
 }


### PR DESCRIPTION
This required adjusting EksSubtreeDispatcher and EksSearchProviderApp
to support placing multiple interface descriptors on a single object
in the bus subtree. When the "subtree-dispatch" signal is emitted
we now check the interface name to check what to do.

https://phabricator.endlessm.com/T16569