### PR TITLE
DiscoveryFeed: return shard-paths with ArticleCardDescriptions

### DIFF
--- a/search-provider/eks-discovery-feed-provider-dbus.xml
+++ b/search-provider/eks-discovery-feed-provider-dbus.xml
@@ -19,6 +19,7 @@
 <node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
   <interface name="com.endlessm.DiscoveryFeedContent">
     <method name="ArticleCardDescriptions">
+      <arg type="as" name="Shards" direction="out" />
       <arg type="aa{ss}" name="Results" direction="out" />
     </method>
   </interface>


### PR DESCRIPTION
We do not want to rely on eos-knowledge-content in eos-discovery-feed
and therefore need information of the shard's path that we
can load shard info from the path directly.

https://phabricator.endlessm.com/T16775