### PR TITLE
search: fix global search regression

### DIFF
--- a/search-provider/eks-search-app.c
+++ b/search-provider/eks-search-app.c
@@ -152,7 +152,8 @@ subtree_object_info_for_interface (EksSearchApp      *self,
                                    const gchar       *interface,
                                    SubtreeObjectInfo *info)
 {
-  if (g_strcmp0 (interface, "org.gnome.Shell.SearchProvider") == 0)
+  if (g_strcmp0 (interface, "org.gnome.Shell.SearchProvider") == 0 ||
+      g_strcmp0 (interface, "org.gnome.Shell.SearchProvider2") == 0)
     {
       info->create_type = EKS_TYPE_SEARCH_PROVIDER;
       info->cache = self->app_search_providers;


### PR DESCRIPTION
We should return the search provider interface also for the v2 of it,
which is what all of our apps use.

https://phabricator.endlessm.com/T17100