### PR TITLE
Build against com.endlessm.apps.Platform//1

### DIFF
--- a/com.endlessm.EknServices.json.in
+++ b/com.endlessm.EknServices.json.in
@@ -1,8 +1,8 @@
 {
     "app-id": "com.endlessm.EknServices",
-    "runtime": "com.endlessm.Platform",
-    "runtime-version": "@BRANCH@",
-    "sdk": "com.endlessm.Sdk",
+    "runtime": "com.endlessm.apps.Platform",
+    "runtime-version": "1",
+    "sdk": "com.endlessm.apps.Sdk",
     "finish-args": [
         "--filesystem=/var/lib/flatpak:ro",
         "--filesystem=/var/endless-extra/flatpak:ro",


### PR DESCRIPTION
From now on, the version of the SDK that we build against is separate
from the branch that we are building on. They are not updated in sync;
eos-knowledge-services should be ported to stable version 2 explicitly
when the time comes.

https://phabricator.endlessm.com/T17645