### PR TITLE
search-provider: Don't pollute results with images

### DIFF
--- a/search-provider/eks-search-provider.c
+++ b/search-provider/eks-search-provider.c
@@ -211,11 +211,17 @@ do_search (EksSearchProvider *self,
 
   g_application_hold (g_application_get_default ());
 
+  GVariantBuilder tags_match_any_builder;
+  g_variant_builder_init (&tags_match_any_builder, G_VARIANT_TYPE ("as"));
+  g_variant_builder_add (&tags_match_any_builder, "s", "EknArticleObject");
+  GVariant *tags_match_any = g_variant_builder_end (&tags_match_any_builder);
+
   self->cancellable = g_cancellable_new ();
   g_autoptr(EkncQueryObject) query_obj = g_object_new (EKNC_TYPE_QUERY_OBJECT,
                                                         "query", query,
                                                         "limit", RESULTS_LIMIT,
                                                         "app-id", self->application_id,
+                                                        "tags-match-any", tags_match_any,
                                                         NULL);
   SearchState *state = g_slice_new0 (SearchState);
   state->self = self;


### PR DESCRIPTION
Since a couple months we started indexing every asset title
and not only for articles, in our content xapian database.

This means that the search provider results can include all
sorts of asset, even those we can't properly display in our
apps, e.g. individual images from our articles.

This issue is now visible with the new SEA apps, the images
completely pollute the results of results, pretty unusable.

Therefore, specify in the query that we want articles.

https://phabricator.endlessm.com/T18139