### PR TITLE
feed: Use hookTitle attribute, not blurbs

### DIFF
--- a/search-provider/eks-discovery-feed-provider.c
+++ b/search-provider/eks-discovery-feed-provider.c
@@ -530,7 +530,7 @@ article_card_descriptions_cb (GObject *source,
 
           while (g_variant_iter_loop (&discovery_feed_content_iter, "{sv}", &key, &value))
             {
-              if (g_strcmp0 (key, "blurbs") == 0)
+              if (g_strcmp0 (key, "hookTitle") == 0)
                 {
                   g_autofree gchar *title = select_string_from_variant_from_day (value);
 


### PR DESCRIPTION
This is what is used in the subscription apps definitions
and we want to be consistent throughout

https://phabricator.endlessm.com/T18504