### PR TITLE
feed: Use xapian's "offset" operator to handle offsets

### DIFF
--- a/search-provider/eks-discovery-feed-provider.c
+++ b/search-provider/eks-discovery-feed-provider.c
@@ -707,7 +707,7 @@ handle_artwork_card_descriptions (EksDiscoveryFeedDatabaseContentProvider *skele
 {
     EksDiscoveryFeedDatabaseContentProvider *self = user_data;
 
-    if (!ensure_content_app_proxy (self))
+    if (!ensure_artwork_app_proxy (self))
       return TRUE;
 
     EkncEngine *engine = eknc_engine_get_default ();

--- a/search-provider/eks-discovery-feed-provider.c
+++ b/search-provider/eks-discovery-feed-provider.c
@@ -10,6 +10,7 @@
 #include <eos-shard/eos-shard-shard-file.h>
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #define NUMBER_OF_ARTICLES 5

--- a/search-provider/eks-discovery-feed-provider.c
+++ b/search-provider/eks-discovery-feed-provider.c
@@ -860,7 +860,6 @@ handle_content_article_card_descriptions (EksDiscoveryFeedDatabaseContentProvide
     GVariantBuilder tags_match_all_builder;
     g_variant_builder_init (&tags_match_all_builder, G_VARIANT_TYPE ("as"));
     g_variant_builder_add (&tags_match_all_builder, "s", "EknHasDiscoveryFeedTitle");
-    GVariant *tags_match_all = g_variant_builder_end (&tags_match_all_builder);
 
     /* Hold the application so that it doesn't go away whilst we're handling
      * the query */


### PR DESCRIPTION
This offloads all the offsetting to the database side as opposed
to doing it on the client side where we query information for N
models, read them all in from the shard and throw 90% of that
information away.

On an SSD, this sped up queries by a factor of 6x. It will probably
speed them up even more on an HDD.

However, it comes at a cost. The offset operator in Xapian does not
understand the concept of "wrapping around", so in the case where
we want to offset by get_day_of_year (), if day_of_year > n_models
the query will just return nothing. Unfortunately, the content
apps that we want to ship with all have about 75 pieces of content
each with eligible titles, which means that all of them would have
been out of range at around this time during the year. In order
to account for that, this commit adds a hardcoded wraparound
constant of 70.

https://phabricator.endlessm.com/T18569