### PR TITLE
Evergreen content: the actual quote is in the article title field

### DIFF
--- a/search-provider/eks-discovery-feed-provider.c
+++ b/search-provider/eks-discovery-feed-provider.c
@@ -914,7 +914,7 @@ get_quote_of_the_day_content_cb (GObject *source,
   gint index = get_day_of_year () % g_slist_length (models);
   EkncContentObjectModel *model = g_slist_nth (models, index)->data;
 
-  add_key_value_pair_from_model_to_variant (model, &builder, "quote");
+  add_key_value_pair_from_model_to_variant (model, &builder, "title");
   add_author_from_model_to_variant (model, &builder, "author");
   add_key_value_pair_from_model_to_variant (model, &builder, "ekn-id");
 


### PR DESCRIPTION
For QuoteOfTheDay we reused the article model as it has a
text field and an author field, all which is needed to
represent an actual quote.

https://phabricator.endlessm.com/T18918