### PR TITLE
feed: Improve robustness of error handling

### DIFF
--- a/search-provider/eks-discovery-feed-provider.c
+++ b/search-provider/eks-discovery-feed-provider.c
@@ -328,6 +328,7 @@ typedef struct _QueryPendingUpperBound {
   GCancellable        *cancellable;
   GAsyncReadyCallback main_query_ready_callback;
   gpointer            main_query_ready_data;
+  GDestroyNotify      main_query_ready_destroy;
 } QueryPendingUpperBound;
 
 static QueryPendingUpperBound *
@@ -336,7 +337,8 @@ query_pending_upper_bound_new (EkncQueryObject     *query,
                                guint               wraparound_upper_bound,
                                GCancellable        *cancellable,
                                GAsyncReadyCallback main_query_ready_callback,
-                               gpointer            main_query_ready_data)
+                               gpointer            main_query_ready_data,
+                               GDestroyNotify      main_query_ready_destroy)
 {
   QueryPendingUpperBound *data = g_new0 (QueryPendingUpperBound, 1);
   data->query = g_object_ref (query);
@@ -347,6 +349,7 @@ query_pending_upper_bound_new (EkncQueryObject     *query,
   data->cancellable = cancellable ? g_object_ref (cancellable) : NULL;
   data->main_query_ready_callback = main_query_ready_callback;
   data->main_query_ready_data = main_query_ready_data;
+  data->main_query_ready_destroy = main_query_ready_destroy;
 
   return data;
 }
@@ -356,6 +359,7 @@ query_pending_upper_bound_free (QueryPendingUpperBound *data)
 {
   g_object_unref (data->query);
   g_clear_object (&data->cancellable);
+  g_clear_pointer (&data->main_query_ready_data, data->main_query_ready_destroy);
 
   g_free (data);
 }
@@ -401,7 +405,7 @@ on_received_upper_bound_result (GObject      *source,
                      pending->query,
                      pending->cancellable,
                      pending->main_query_ready_callback,
-                     pending->main_query_ready_data);
+                     g_steal_pointer (&pending->main_query_ready_data));
 }
 
 /* This function executes the given query with an offset computed
@@ -421,7 +425,8 @@ query_with_wraparound_offset (EkncEngine          *engine,
                               guint               wraparound_upper_bound,
                               GCancellable        *cancellable,
                               GAsyncReadyCallback main_query_ready_callback,
-                              gpointer            main_query_ready_data)
+                              gpointer            main_query_ready_data,
+                              gpointer            main_query_ready_destroy)
 {
   /* Override the limit, setting it to one. In the returned query we'll get
    * nothing back, but Xapian will tell us how many models matched our query
@@ -442,7 +447,8 @@ query_with_wraparound_offset (EkncEngine          *engine,
                                                     wraparound_upper_bound,
                                                     cancellable,
                                                     main_query_ready_callback,
-                                                    main_query_ready_data));
+                                                    main_query_ready_data,
+                                                    main_query_ready_destroy));
 }
 
 static void
@@ -576,7 +582,8 @@ handle_artwork_card_descriptions (EksDiscoveryFeedDatabaseContentProvider *skele
                                   DAYS_IN_YEAR,
                                   self->cancellable,
                                   artwork_card_descriptions_cb,
-                                  discovery_feed_query_state_new (invocation, self));
+                                  discovery_feed_query_state_new (invocation, self),
+                                  (GDestroyNotify) discovery_feed_query_state_free);
 
     return TRUE;
 }
@@ -715,7 +722,8 @@ handle_content_article_card_descriptions (EksDiscoveryFeedDatabaseContentProvide
                                   DAYS_IN_YEAR,
                                   self->cancellable,
                                   content_article_card_descriptions_cb,
-                                  discovery_feed_query_state_new (invocation, self));
+                                  discovery_feed_query_state_new (invocation, self),
+                                  (GDestroyNotify) discovery_feed_query_state_free);
 
     return TRUE;
 }
@@ -791,7 +799,8 @@ handle_get_word_of_the_day (EksDiscoveryFeedDatabaseContentProvider *skeleton,
                                   DAYS_IN_YEAR,
                                   self->cancellable,
                                   get_word_of_the_day_content_cb,
-                                  discovery_feed_query_state_new (invocation, self));
+                                  discovery_feed_query_state_new (invocation, self),
+                                  (GDestroyNotify) discovery_feed_query_state_free);
 
     return TRUE;
 }
@@ -865,7 +874,8 @@ handle_get_quote_of_the_day (EksDiscoveryFeedDatabaseContentProvider *skeleton,
                                   DAYS_IN_YEAR,
                                   self->cancellable,
                                   get_quote_of_the_day_content_cb,
-                                  discovery_feed_query_state_new (invocation, self));
+                                  discovery_feed_query_state_new (invocation, self),
+                                  (GDestroyNotify) discovery_feed_query_state_free);
 
     return TRUE;
 }

--- a/search-provider/eks-discovery-feed-provider.c
+++ b/search-provider/eks-discovery-feed-provider.c
@@ -322,23 +322,25 @@ strv_from_shard_list (GSList *string_list)
 }
 
 typedef struct _QueryPendingUpperBound {
-  EkncQueryObject     *query;
-  guint               offset_within_upper_bound;
-  guint               wraparound_upper_bound;
-  GCancellable        *cancellable;
-  GAsyncReadyCallback main_query_ready_callback;
-  gpointer            main_query_ready_data;
-  GDestroyNotify      main_query_ready_destroy;
+  EkncQueryObject       *query;
+  guint                 offset_within_upper_bound;
+  guint                 wraparound_upper_bound;
+  GCancellable          *cancellable;
+  GDBusMethodInvocation *invocation;
+  GAsyncReadyCallback   main_query_ready_callback;
+  gpointer              main_query_ready_data;
+  GDestroyNotify        main_query_ready_destroy;
 } QueryPendingUpperBound;
 
 static QueryPendingUpperBound *
-query_pending_upper_bound_new (EkncQueryObject     *query,
-                               guint               offset_within_upper_bound,
-                               guint               wraparound_upper_bound,
-                               GCancellable        *cancellable,
-                               GAsyncReadyCallback main_query_ready_callback,
-                               gpointer            main_query_ready_data,
-                               GDestroyNotify      main_query_ready_destroy)
+query_pending_upper_bound_new (EkncQueryObject       *query,
+                               guint                  offset_within_upper_bound,
+                               guint                  wraparound_upper_bound,
+                               GDBusMethodInvocation *invocation,
+                               GCancellable          *cancellable,
+                               GAsyncReadyCallback    main_query_ready_callback,
+                               gpointer               main_query_ready_data,
+                               GDestroyNotify         main_query_ready_destroy)
 {
   QueryPendingUpperBound *data = g_new0 (QueryPendingUpperBound, 1);
   data->query = g_object_ref (query);
@@ -347,6 +349,7 @@ query_pending_upper_bound_new (EkncQueryObject     *query,
 
   /* Keep cancellable alive if we got one, otherwise ignore it */
   data->cancellable = cancellable ? g_object_ref (cancellable) : NULL;
+  data->invocation = g_object_ref (invocation);
   data->main_query_ready_callback = main_query_ready_callback;
   data->main_query_ready_data = main_query_ready_data;
   data->main_query_ready_destroy = main_query_ready_destroy;
@@ -359,6 +362,7 @@ query_pending_upper_bound_free (QueryPendingUpperBound *data)
 {
   g_object_unref (data->query);
   g_clear_object (&data->cancellable);
+  g_object_unref (data->invocation);
   g_clear_pointer (&data->main_query_ready_data, data->main_query_ready_destroy);
 
   g_free (data);
@@ -381,6 +385,11 @@ on_received_upper_bound_result (GObject      *source,
     {
       g_warning ("Unable to get upper bound on results, aborting query: %s",
                  error->message);
+      g_dbus_method_invocation_take_error (pending->invocation,
+                                           g_steal_pointer (&error));
+
+      /* No need to free_full the out models and shards here,
+       * g_slist_copy_deep is not called if this function returns early. */
       return;
     }
 
@@ -419,14 +428,15 @@ on_received_upper_bound_result (GObject      *source,
  * in the limit parameter to the query
  */
 static void
-query_with_wraparound_offset (EkncEngine          *engine,
-                              EkncQueryObject     *query,
-                              guint               offset_within_upper_bound,
-                              guint               wraparound_upper_bound,
-                              GCancellable        *cancellable,
-                              GAsyncReadyCallback main_query_ready_callback,
-                              gpointer            main_query_ready_data,
-                              gpointer            main_query_ready_destroy)
+query_with_wraparound_offset (EkncEngine            *engine,
+                              EkncQueryObject       *query,
+                              guint                  offset_within_upper_bound,
+                              guint                  wraparound_upper_bound,
+                              GDBusMethodInvocation *invocation,
+                              GCancellable          *cancellable,
+                              GAsyncReadyCallback    main_query_ready_callback,
+                              gpointer               main_query_ready_data,
+                              GDestroyNotify         main_query_ready_destroy)
 {
   /* Override the limit, setting it to one. In the returned query we'll get
    * nothing back, but Xapian will tell us how many models matched our query
@@ -445,6 +455,7 @@ query_with_wraparound_offset (EkncEngine          *engine,
                      query_pending_upper_bound_new (query,
                                                     offset_within_upper_bound,
                                                     wraparound_upper_bound,
+                                                    invocation,
                                                     cancellable,
                                                     main_query_ready_callback,
                                                     main_query_ready_data,
@@ -580,6 +591,7 @@ handle_artwork_card_descriptions (EksDiscoveryFeedDatabaseContentProvider *skele
                                                 NULL),
                                   get_day_of_year (),
                                   DAYS_IN_YEAR,
+                                  invocation,
                                   self->cancellable,
                                   artwork_card_descriptions_cb,
                                   discovery_feed_query_state_new (invocation, self),
@@ -720,6 +732,7 @@ handle_content_article_card_descriptions (EksDiscoveryFeedDatabaseContentProvide
                                                 NULL),
                                   get_day_of_year (),
                                   DAYS_IN_YEAR,
+                                  invocation,
                                   self->cancellable,
                                   content_article_card_descriptions_cb,
                                   discovery_feed_query_state_new (invocation, self),
@@ -797,6 +810,7 @@ handle_get_word_of_the_day (EksDiscoveryFeedDatabaseContentProvider *skeleton,
                                                 NULL),
                                   get_day_of_year (),
                                   DAYS_IN_YEAR,
+                                  invocation,
                                   self->cancellable,
                                   get_word_of_the_day_content_cb,
                                   discovery_feed_query_state_new (invocation, self),
@@ -872,6 +886,7 @@ handle_get_quote_of_the_day (EksDiscoveryFeedDatabaseContentProvider *skeleton,
                                                 NULL),
                                   get_day_of_year (),
                                   DAYS_IN_YEAR,
+                                  invocation,
                                   self->cancellable,
                                   get_quote_of_the_day_content_cb,
                                   discovery_feed_query_state_new (invocation, self),


### PR DESCRIPTION
If the intermediate query to determine the number of results fails,
make sure to return an error on the d-bus method invocation and
free the query state appropriately

https://phabricator.endlessm.com/T18486