### PR TITLE
build: Use current checkout for module source

### DIFF
--- a/com.endlessm.EknServices.json.in
+++ b/com.endlessm.EknServices.json.in
@@ -17,8 +17,8 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://c5a7fd3e12c1d7b20bbff48a541d36f92d1e5a2d@github.com/endlessm/eos-knowledge-services.git",
-                    "branch": "master"
+                    "path": ".",
+                    "branch": "@GIT_CLONE_BRANCH@"
                 }
             ]
         }


### PR DESCRIPTION
Instead of cloning from github again and having to provide some kind of
authentication, use the current directory as the git source.
Unfortunately, hardcoding the branch doesn't work right in jenkins since
it does detached head checkouts. Substitute the @GIT_CLONE_BRANCH@
value, which will be the currently building commit in jenkins. The
jenkins-build-flatpak-manifest script has already been updated to do
this substitution.

This does make the manifest a template, unfortunately. I didn't rename
it since that would break all the jenkins jobs, but that would probably
be a good idea.

https://phabricator.endlessm.com/T20243