### PR TITLE
discovery-feed: Adapt to EknContent property type change

### DIFF
--- a/search-provider/eks-discovery-feed-provider.c
+++ b/search-provider/eks-discovery-feed-provider.c
@@ -230,8 +230,8 @@ select_string_from_array_from_day (JsonArray *array)
   if (size == 0)
     return NULL;
 
-  gint index = get_day_of_week () % size;
-  return json_array_get_string_element (array, index);
+  int ix = get_day_of_week () % size;
+  return json_array_get_string_element (array, ix);
 }
 
 typedef enum {


### PR DESCRIPTION
The EkncContentObjectModel:discovery-feed-content property is now a
JsonObject instead of a GVariant. We get the required node directly,
thereby avoiding another GVariant conversion step.

https://phabricator.endlessm.com/T20702