### PR TITLE
search-provider: Add EksContentMetdata provider

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -48,6 +48,14 @@ search-provider/eks-knowledge-app-dbus.h search-provider/eks-knowledge-app-dbus.
 	--generate-c-code search-provider/eks-knowledge-app-dbus \
 	$<
 
+search-provider/eks-metadata-provider-dbus.h search-provider/eks-metadata-provider-dbus.c: search-provider/eks-metadata-provider-dbus.xml Makefile.am
+	$(AM_V_GEN) $(MKDIR_P) $(@D) && \
+	$(GDBUS_CODEGEN) \
+	--interface-prefix=com.endlessm. \
+	--c-namespace Eks \
+	--generate-c-code search-provider/eks-metadata-provider-dbus \
+	$<
+
 search-provider/eks-search-provider-dbus.h search-provider/eks-search-provider-dbus.c: search-provider/eks-search-provider-dbus.xml Makefile.am
 	$(AM_V_GEN) $(MKDIR_P) $(@D) && \
 	$(GDBUS_CODEGEN) \
@@ -59,6 +67,7 @@ search-provider/eks-search-provider-dbus.h search-provider/eks-search-provider-d
 EXTRA_DIST += \
 	search-provider/eks-discovery-feed-provider-dbus.xml \
 	search-provider/eks-knowledge-app-dbus.xml \
+	search-provider/eks-metadata-provider-dbus.xml \
 	search-provider/eks-search-provider-dbus.xml \
 	$(NULL)
 
@@ -67,6 +76,8 @@ BUILT_SOURCES = \
 	search-provider/eks-discovery-feed-provider-dbus.c \
 	search-provider/eks-knowledge-app-dbus.h \
 	search-provider/eks-knowledge-app-dbus.c \
+	search-provider/eks-metadata-provider-dbus.h \
+	search-provider/eks-metadata-provider-dbus.c \
 	search-provider/eks-search-provider-dbus.h \
 	search-provider/eks-search-provider-dbus.c \
 	$(NULL)
@@ -80,6 +91,10 @@ eks_search_provider_v2_SOURCES = \
 	search-provider/eks-errors.h \
 	search-provider/eks-knowledge-app-dbus.c \
 	search-provider/eks-knowledge-app-dbus.h \
+	search-provider/eks-metadata-provider.c \
+	search-provider/eks-metadata-provider.h \
+	search-provider/eks-metadata-provider-dbus.c \
+	search-provider/eks-metadata-provider-dbus.h \
 	search-provider/eks-provider-iface.h \
 	search-provider/eks-provider-iface.c \
 	search-provider/eks-query-util.c \

--- a/search-provider/eks-discovery-feed-provider.c
+++ b/search-provider/eks-discovery-feed-provider.c
@@ -398,6 +398,7 @@ artwork_card_descriptions_cb (GObject *source,
                                      result,
                                      &models,
                                      &shards,
+                                     NULL,
                                      &error))
     {
       g_dbus_method_invocation_take_error (state->invocation, error);
@@ -494,6 +495,7 @@ content_article_card_descriptions_cb (GObject *source,
                                      result,
                                      &models,
                                      &shards,
+                                     NULL,
                                      &error))
     {
       g_dbus_method_invocation_take_error (state->invocation, error);
@@ -614,6 +616,7 @@ get_word_of_the_day_content_cb (GObject *source,
                           state->provider->application_id,
                           result,
                           &models,
+                          NULL,
                           &error))
     {
       g_dbus_method_invocation_take_error (state->invocation, error);
@@ -686,6 +689,7 @@ get_quote_of_the_day_content_cb (GObject *source,
                           state->provider->application_id,
                           result,
                           &models,
+                          NULL,
                           &error))
     {
       g_dbus_method_invocation_take_error (state->invocation, error);
@@ -759,6 +763,7 @@ recent_news_articles_cb (GObject *source,
                                      result,
                                      &models,
                                      &shards,
+                                     NULL,
                                      &error))
     {
       g_dbus_method_invocation_take_error (state->invocation, error);
@@ -845,6 +850,7 @@ relevant_video_cb (GObject *source,
                                      result,
                                      &models,
                                      &shards,
+                                     NULL,
                                      &error))
     {
       g_dbus_method_invocation_take_error (state->invocation, error);

--- a/search-provider/eks-metadata-provider-dbus.xml
+++ b/search-provider/eks-metadata-provider-dbus.xml
@@ -1,0 +1,141 @@
+<!DOCTYPE node PUBLIC
+"-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+
+<!--
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General
+ Public License along with this library; if not, see <http://www.gnu.org/licenses/>.
+-->
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <interface name="com.endlessm.ContentMetadata">
+    <!--
+        Query:
+        @Query: An array of dictionaries describing the queries to be made,
+                with the following optional parameters. Specifying any
+                parameter that is not a member of this list is an error.
+                No new parameters will be added or removed from this
+                interface during its lifetime.
+
+                "search-terms": A string (s) with the free-text search terms
+                                to use during the query. If the parameter
+                                is not specified, filtering will only
+                                be done against tags-match-any and tags-match-all.
+                "tags-match-any": A strv (as) with a list of tags that any
+                                  matching content objects must have at least
+                                  one of.
+                "tags-match-all": A strv (as) with a list of tags that any
+                                  matching content objects must have all of.
+                "limit": An integer indicating the number of results at most
+                         to return. If the parameter is not specifed there
+                         will be no limit.
+                "offset": An integer specifying the "offset" into the query
+                          results from the point which it start returning results.
+                          This also changes the index of the last result if "limit"
+                          was specified. For instance, if "offset" was 1 and
+                          "limit" was 5, then the 2nd to 6th results will
+                          be returned, inclusive.
+                "sort": A string specifying what the query should be sorted by,
+                        valid values are:
+
+                            "relevance": Sort by relevance ranking, with exact
+                                         title matches weighted most heavily.
+                            "sequence-number": Sort by article page ranking.
+                            "date": Sort by date of publication.
+                            "alphabetical" Sort alphabetically.
+
+                "order": A string specifying how sorted query results should
+                         be ordered, valid values are:
+
+                             "ascending": Least-ranked to most-ranked.
+                             "descending": Most-ranked to least-ranked.
+
+       Run a query against the database for this app.
+
+       Returns a tuple of @Shards and @Results.
+       @Shards: An array of strings indicating the file-paths where
+                shard packfiles are kept on the filesystem which contain
+                the actual data for results in the query. A call to Query
+                might return multiple shards, so if the client wants to look
+                up further information for a particular content object, they
+                will need to check every shard to see if it has that content.
+       @Results: An array of tuples of (result-metadata, models). The result
+                 tuples come back in the same order corresponding to the
+                 query dictionaries passed in @Query. If any one query fails
+                 the entire query operation fails.
+
+                 result-metadata a dictionary containing metadata about the
+                 result. New priperties may be added to these dictionaries
+                 during the course of the interface's lifetime, so callers
+                 should explicitly check if the property is present on the
+                 returned dictionary for each piece of content before attempting
+                 to use it, and if not, substituting a sensible default.
+
+                 "upper_bound": the number of models that would be returned
+                                in a search result if "limit" had not been
+                                applied.
+
+                 models is an array of dictionaries with metadata about each
+                 content object matched in the query. New properties may be
+                 added to these dictionaries during the course of this
+                 interface's lifetime, so callers should explicitly check if
+                 the property is present on the returned dictionary for each
+                 piece of content before attempting to use it, and if not,
+                 substitute a sensible default.
+
+                 "title": The title of the content object.
+                 "content_type": The MIME type of the underlying content data.
+                 "language": The language code of the content.
+                 "synopsis": A brief description of the content.
+                 "last_modified_date": Date (ISO8061) when the content was
+                                       last modified.
+                 "original_title": The original title this content had.
+                 "original_uri": The URI that this content was sourced from.
+                 "license": License for this content.
+                 "copyright_holder": Who holds the copyright for this content.
+                 "thumbnail_uri": An EKN ID specifying the location in one
+                                  of the returned shards where data for
+                                  the thumbnail for this content is stored.
+                 "ekn_id": An EKN ID specifying the location in one of the
+                           returned shards where data for this content is
+                           stored.
+                 "child_tags": If this content object model represents a
+                               set, the tags which should be queried as part
+                               of "tags-match-any" in Query above to find
+                               content objects inside this set.
+                 "tags": The tags for this content object model, which allow
+                         it to be associated with a set via "child_tags" or
+                         provide metadata about the type of content.
+                 "temporal-coverage": The dates this content covers.
+                 "discovery_feed_content": An opaque struct with content for
+                                           the discovery feed.
+    -->
+    <method name="Query">
+      <arg type="as" name="Shards" direction="out" />
+      <arg type="a(a{sv}aa{sv})" name="Results" direction="out" />
+      <arg type="aa{sv}" name="Query" direction="in" />
+    </method>
+    <!--
+        Shards:
+        Just return the location for the shards for this app without running
+        a query against its database. This is useful if the caller already
+        knows an EKN ID that they need to look up for an app and just needs
+        to know where its shard file is.
+
+        Returns @Shards: an array of strings with file paths for where the shard
+                         packfiles for this app are stored.
+    -->
+    <method name="Shards">
+      <arg type="as" name="Shards" direction="out" />
+    </method>
+  </interface>
+</node>

--- a/search-provider/eks-metadata-provider.c
+++ b/search-provider/eks-metadata-provider.c
@@ -300,7 +300,7 @@ on_received_query_results (GObject      *source,
                                      &error))
     {
       g_dbus_method_invocation_take_error (state->invocation,
-                                           g_steal_pointer (&error));
+                                           eks_map_error_to_eks_error (error));
       g_slist_free_full (models, g_object_unref);
       g_slist_free_full (shards, g_object_unref);
       return;
@@ -674,7 +674,7 @@ handle_shards (EksContentMetadata    *skeleton,
   if (domain == NULL)
     {
       g_dbus_method_invocation_take_error (invocation,
-                                           g_steal_pointer (&error));
+                                           eks_map_error_to_eks_error (error));
       return TRUE;
     }
 

--- a/search-provider/eks-metadata-provider.c
+++ b/search-provider/eks-metadata-provider.c
@@ -1,0 +1,718 @@
+/* Copyright 2018 Endless Mobile, Inc. */
+
+#include <dmodel.h>
+#include "dm-enums.h"
+
+#include "eks-errors.h"
+#include "eks-provider-iface.h"
+#include "eks-query-util.h"
+
+#include "eks-knowledge-app-dbus.h"
+#include "eks-metadata-provider.h"
+#include "eks-metadata-provider-dbus.h"
+
+#include <eos-shard/eos-shard-shard-file.h>
+
+#include <json-glib/json-glib.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct _EksMetadataProvider
+{
+  GObject parent_instance;
+
+  char *application_id;
+  EksContentMetadata *skeleton;
+  GHashTable *translation_infos;
+};
+
+static void eks_metadata_provider_interface_init (EksProviderInterface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (EksMetadataProvider,
+                         eks_metadata_provider,
+                         G_TYPE_OBJECT,
+                         G_IMPLEMENT_INTERFACE (EKS_TYPE_PROVIDER,
+                                                eks_metadata_provider_interface_init))
+
+enum {
+  PROP_0,
+  PROP_APPLICATION_ID,
+  NPROPS
+};
+
+static GParamSpec *eks_metadata_provider_props [NPROPS] = { NULL, };
+
+static void
+eks_metadata_provider_get_property (GObject    *object,
+                                    guint       prop_id,
+                                    GValue     *value,
+                                    GParamSpec *pspec)
+{
+  EksMetadataProvider *self = EKS_METADATA_PROVIDER (object);
+
+  switch (prop_id)
+    {
+    case PROP_APPLICATION_ID:
+      g_value_set_string (value, self->application_id);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+eks_metadata_provider_set_property (GObject      *object,
+                                    unsigned      prop_id,
+                                    const GValue *value,
+                                    GParamSpec   *pspec)
+{
+  EksMetadataProvider *self = EKS_METADATA_PROVIDER (object);
+
+  switch (prop_id)
+    {
+    case PROP_APPLICATION_ID:
+      g_clear_pointer (&self->application_id, g_free);
+      self->application_id = g_value_dup_string (value);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+eks_metadata_provider_finalize (GObject *object)
+{
+  EksMetadataProvider *self = EKS_METADATA_PROVIDER (object);
+
+  g_clear_pointer (&self->application_id, g_free);
+  g_clear_object (&self->skeleton);
+  g_clear_pointer (&self->translation_infos, g_hash_table_unref);
+
+  G_OBJECT_CLASS (eks_metadata_provider_parent_class)->finalize (object);
+}
+
+static void
+eks_metadata_provider_class_init (EksMetadataProviderClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->get_property = eks_metadata_provider_get_property;
+  object_class->set_property = eks_metadata_provider_set_property;
+  object_class->finalize = eks_metadata_provider_finalize;
+
+  eks_metadata_provider_props[PROP_APPLICATION_ID] =
+    g_param_spec_string ("application-id", "Application Id", "Application Id",
+      "", G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
+
+  g_object_class_install_properties (object_class,
+                                     NPROPS,
+                                     eks_metadata_provider_props);
+}
+
+typedef struct _MetadataQueryState {
+  EksMetadataProvider   *provider;
+  GDBusMethodInvocation *invocation;
+} MetadataQueryState;
+
+static MetadataQueryState *
+metadata_query_state_new (EksMetadataProvider   *provider,
+                          GDBusMethodInvocation *invocation)
+{
+  MetadataQueryState *state = g_new0 (MetadataQueryState, 1);
+  state->provider = provider;
+  state->invocation = g_object_ref (invocation);
+
+  return state;
+}
+
+static void
+metadata_query_state_free (MetadataQueryState *state)
+{
+  g_clear_object (&state->invocation);
+
+  g_free (state);
+}
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (MetadataQueryState,
+                               metadata_query_state_free)
+
+static void
+add_key_value_pair_to_variant (GVariantBuilder *builder,
+                               const char      *key,
+                               GVariant        *value)
+{
+  g_variant_builder_open (builder, G_VARIANT_TYPE ("{sv}"));
+  g_variant_builder_add (builder, "s", key);
+  g_variant_builder_add (builder, "v", value);
+  g_variant_builder_close (builder);
+}
+
+static gboolean
+gvalue_to_variant_internal (GValue              *value,
+                            const GVariantType  *expected_type,
+                            GVariant           **out_variant,
+                            GError             **error)
+{
+  g_return_val_if_fail (out_variant != NULL, FALSE);
+
+  /* Special case: if expected_type is G_VARIANT_TYPE_VARDICT then we need
+   * to deserialize from JsonObject. */
+  if (expected_type == G_VARIANT_TYPE_VARDICT)
+    {
+      JsonObject *object = g_value_get_boxed (value);
+
+      if (object == NULL)
+        return TRUE;
+
+      g_autoptr(JsonNode) node = json_node_new (JSON_NODE_OBJECT);
+
+      json_node_init_object (node, object);
+      *out_variant = json_gvariant_deserialize (node,
+                                                NULL,
+                                                error);
+      return *out_variant != NULL;
+    }
+
+  *out_variant = g_dbus_gvalue_to_gvariant (value, expected_type);
+  return *out_variant != NULL;
+}
+
+static gboolean
+maybe_add_key_value_pair_from_model_to_variant (DmContent           *model,
+                                                GVariantBuilder     *builder,
+                                                const char          *key,
+                                                const GVariantType  *expected_type,
+                                                GError             **error)
+{
+  g_auto(GValue) value = G_VALUE_INIT;
+  GParamSpec *pspec = g_object_class_find_property (G_OBJECT_GET_CLASS (model),
+                                                    key);
+  g_autoptr(GVariant) converted = NULL;
+
+  if (pspec == NULL)
+    return TRUE;
+
+  g_value_init (&value, pspec->value_type);
+  g_object_get_property (G_OBJECT (model), key, &value);
+
+  if (!gvalue_to_variant_internal (&value, expected_type, &converted, error))
+    return FALSE;
+
+  /* If we got NULL here it just means that the source property was NULL,
+   * so don't add it. */
+  if (converted == NULL)
+    return TRUE;
+
+  add_key_value_pair_to_variant (builder, key, g_steal_pointer (&converted));
+  return TRUE;
+}
+
+typedef struct _ModelVariantTypes {
+  const gchar        *prop_name;
+  const GVariantType *variant_type;
+} ModelVariantTypes;
+
+static const ModelVariantTypes model_variant_types[] = {
+  { "child_tags", G_VARIANT_TYPE_STRING_ARRAY },
+  { "content_type", G_VARIANT_TYPE_STRING },
+  { "copyright_holder", G_VARIANT_TYPE_STRING },
+  { "discovery_feed_content", G_VARIANT_TYPE_VARDICT },
+  { "ekn_id", G_VARIANT_TYPE_STRING },
+  { "language", G_VARIANT_TYPE_STRING },
+  { "last_modified_date", G_VARIANT_TYPE_STRING },
+  { "license", G_VARIANT_TYPE_STRING },
+  { "original_title", G_VARIANT_TYPE_STRING },
+  { "original_uri", G_VARIANT_TYPE_STRING },
+  { "tags", G_VARIANT_TYPE_STRING_ARRAY },
+  { "temporal_coverage", G_VARIANT_TYPE_STRING_ARRAY },
+  { "title", G_VARIANT_TYPE_STRING },
+  { "thumbnail_uri", G_VARIANT_TYPE_STRING }
+};
+static const gsize model_variant_types_n = G_N_ELEMENTS (model_variant_types);
+
+static GVariant *
+build_models_variants (GSList  *models,
+                       GError **error)
+{
+  g_auto(GVariantBuilder) builder;
+  g_variant_builder_init (&builder, G_VARIANT_TYPE ("aa{sv}"));
+
+  for (GSList *l = models; l; l = l->next)
+    {
+      DmContent *model = l->data;
+      gsize i = 0;
+
+      g_variant_builder_open (&builder, G_VARIANT_TYPE_VARDICT);
+
+      for (; i < model_variant_types_n; ++i)
+        {
+          const ModelVariantTypes *model_prop = &model_variant_types[i];
+
+          if (!maybe_add_key_value_pair_from_model_to_variant (model,
+                                                               &builder,
+                                                               model_prop->prop_name,
+                                                               model_prop->variant_type,
+                                                               error))
+            return NULL;
+        }
+
+      g_variant_builder_close (&builder);
+    }
+
+  return g_variant_builder_end (&builder);
+}
+
+static void
+on_received_query_results (GObject      *source,
+                           GAsyncResult *result,
+                           gpointer      user_data)
+{
+  DmEngine *engine = DM_ENGINE (source);
+  g_autoptr(MetadataQueryState) state = user_data;
+
+  /* Careful here, these two need to be cleaned up manually */
+  GSList *models = NULL;
+  GSList *shards = NULL;
+
+  g_auto(GStrv) shards_strv = NULL;
+  GVariant *results_tuple_array[1];
+  g_autoptr(GVariant) models_variant = NULL;
+  g_auto(GVariantDict) result_metadata;
+  gint upper_bound = 0;
+  g_autoptr(GError) error = NULL;
+
+  /* Make sure to init the vardict first before any return path
+   * otherwise g_auto will attempt to clear uninitialized memory */
+  g_variant_dict_init (&result_metadata, NULL);
+
+  g_application_release (g_application_get_default ());
+
+  if (!models_and_shards_for_result (engine,
+                                     state->provider->application_id,
+                                     result,
+                                     &models,
+                                     &shards,
+                                     &upper_bound,
+                                     &error))
+    {
+      g_dbus_method_invocation_take_error (state->invocation,
+                                           g_steal_pointer (&error));
+      g_slist_free_full (models, g_object_unref);
+      g_slist_free_full (shards, g_object_unref);
+      return;
+    }
+
+  shards_strv = strv_from_shard_list (shards);
+  models_variant = build_models_variants (models, &error);
+
+  if (models_variant == NULL)
+    {
+      g_dbus_method_invocation_take_error (state->invocation,
+                                           eks_map_error_to_eks_error (error));
+      g_slist_free_full (models, g_object_unref);
+      g_slist_free_full (shards, g_object_unref);
+      return;
+    }
+
+  g_variant_dict_insert (&result_metadata, "upper_bound", "i", upper_bound);
+
+  /* Easier than using GVariantBuilder. Note that if a child
+   * has a floating reference the container takes ownership of
+   * them via g_variant_ref_sink, so we need to steal the pointer */
+  results_tuple_array[0] = g_variant_new ("(@a{sv}@aa{sv})",
+                                          g_variant_dict_end (&result_metadata),
+                                          g_steal_pointer (&models_variant));
+  eks_content_metadata_complete_query (state->provider->skeleton,
+                                       state->invocation,
+                                       (const char * const *) shards_strv,
+                                       g_variant_new_array (G_VARIANT_TYPE ("(a{sv}aa{sv})"),
+                                                            results_tuple_array,
+                                                            1));
+
+  g_slist_free_full (models, g_object_unref);
+  g_slist_free_full (shards, g_object_unref);
+}
+
+static void
+append_construction_prop_from_string (const char *key,
+                                      const char *str,
+                                      GArray     *values_array,
+                                      GPtrArray  *props_array)
+{
+  guint index = values_array->len;
+  GValue *value = NULL;
+
+  /* Need to be careful to set value *after* the array has been resized */
+  g_array_set_size (values_array, values_array->len + 1);
+  value = &(g_array_index (values_array, GValue, index));
+  g_value_init (value, G_TYPE_STRING);
+  g_value_set_string (value, str);
+  g_ptr_array_add (props_array, g_strdup (key));
+}
+
+typedef gboolean (*VariantToValueTransformFunc) (GVariant  *variant,
+                                                 GValue    *value,
+                                                 gpointer   user_data,
+                                                 GError   **error);
+
+static gboolean
+translate_gvariant_to_gvalue (GVariant  *variant,
+                              GValue    *value,
+                              gpointer   user_data,
+                              GError   **error)
+{
+  g_dbus_gvariant_to_gvalue (variant, value);
+  return TRUE;
+}
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (GEnumClass, g_type_class_unref)
+
+static gboolean
+translate_gvariant_to_gvalue_parse_enum (GVariant  *variant,
+                                         GValue    *value,
+                                         gpointer   user_data,
+                                         GError   **error)
+{
+  GType enum_type = *((GType *) (user_data));
+  const char *str = g_variant_get_string (variant, NULL);
+  g_autoptr(GEnumClass) klass = g_type_class_ref (enum_type);
+  GEnumValue *enum_value = g_enum_get_value_by_nick (klass, str);
+
+  if (enum_value == NULL)
+    {
+      g_set_error (error,
+                   EKS_ERROR,
+                   EKS_ERROR_INVALID_REQUEST,
+                   "Couldn't translate value '%s' to a valid enum",
+                   str);
+      return FALSE;
+    }
+
+  g_value_init (value, enum_type);
+  g_value_set_enum (value, enum_value->value);
+  return TRUE;
+}
+
+static gboolean
+append_construction_prop_from_variant (const char                   *key,
+                                       GVariant                     *variant,
+                                       GArray                       *values_array,
+                                       GPtrArray                    *props_array,
+                                       VariantToValueTransformFunc   transform,
+                                       gpointer                      user_data,
+                                       GError                      **error)
+{
+  guint index = values_array->len;
+  GValue *value = NULL;
+
+  /* Need to be careful to set value *after* the array has been resized */
+  g_array_set_size (values_array, values_array->len + 1);
+  value = &(g_array_index (values_array, GValue, index));
+
+  /* If we return false from here, this should be treated as an
+   * unrecoverable error for the call */
+  if (!transform (variant, value, user_data, error))
+    return FALSE;
+
+  g_ptr_array_add (props_array, g_strdup (key));
+
+  return TRUE;
+}
+
+static gboolean
+append_construction_prop_from_variant_dbus_transform (const char  *key,
+                                                      GVariant    *variant,
+                                                      GArray      *values_array,
+                                                      GPtrArray   *props_array,
+                                                      gpointer     extra_data,
+                                                      GError     **error)
+{
+  return append_construction_prop_from_variant (key,
+                                                variant,
+                                                values_array,
+                                                props_array,
+                                                translate_gvariant_to_gvalue,
+                                                extra_data,
+                                                error);
+}
+
+static gboolean
+append_construction_prop_from_variant_enum_transform (const char  *key,
+                                                      GVariant    *variant,
+                                                      GArray      *values_array,
+                                                      GPtrArray   *props_array,
+                                                      gpointer     extra_data,
+                                                      GError     **error)
+{
+  return append_construction_prop_from_variant (key,
+                                                variant,
+                                                values_array,
+                                                props_array,
+                                                translate_gvariant_to_gvalue_parse_enum,
+                                                extra_data,
+                                                error);
+}
+
+typedef gboolean (*AppendConstructionPropFromVariantWithTransformFunc) (const char  *key,
+                                                                        GVariant    *variant,
+                                                                        GArray      *values_array,
+                                                                        GPtrArray   *props_array,
+                                                                        gpointer     extra_data,
+                                                                        GError     **error);
+
+typedef struct _ValueTranslationInfo {
+  AppendConstructionPropFromVariantWithTransformFunc append_func;
+  gpointer                                           user_data;
+  GDestroyNotify                                     user_data_destroy;
+} ValueTranslationInfo;
+
+static ValueTranslationInfo *
+value_translation_info_new (AppendConstructionPropFromVariantWithTransformFunc append_func,
+                            gpointer                                           user_data,
+                            GDestroyNotify                                     user_data_destroy)
+{
+  ValueTranslationInfo *info = g_new0 (ValueTranslationInfo, 1);
+
+  info->append_func = append_func;
+  info->user_data = user_data;
+  info->user_data_destroy = user_data_destroy;
+
+  return info;
+}
+
+static void
+value_translation_info_free (ValueTranslationInfo *info)
+{
+  if (info == NULL)
+    return;
+
+  if (info->user_data_destroy)
+    g_clear_pointer (&info->user_data, info->user_data_destroy);
+
+  g_free (info);
+}
+
+/* Note that since GType can be 64-bits, we need to allocate
+ * in order to pass it as user_data. */
+static GType *
+alloc_for_gtype (GType type)
+{
+  GType *typep = g_new0 (GType, 1);
+  *typep = type;
+
+  return typep;
+}
+
+static GHashTable *
+article_metadata_query_construction_props_translation_table (void)
+{
+  g_autoptr(GHashTable) table = g_hash_table_new_full (g_str_hash,
+                                                       g_str_equal,
+                                                       g_free,
+                                                       (GDestroyNotify) value_translation_info_free);
+
+  g_hash_table_insert (table,
+                       g_strdup ("search-terms"),
+                       value_translation_info_new (append_construction_prop_from_variant_dbus_transform,
+                                                   NULL,
+                                                   NULL));
+  g_hash_table_insert (table,
+                       g_strdup ("tags-match-any"),
+                       value_translation_info_new (append_construction_prop_from_variant_dbus_transform,
+                                                   NULL,
+                                                   NULL));
+  g_hash_table_insert (table,
+                       g_strdup ("tags-match-all"),
+                       value_translation_info_new (append_construction_prop_from_variant_dbus_transform,
+                                                   NULL,
+                                                   NULL));
+  g_hash_table_insert (table,
+                       g_strdup ("limit"),
+                       value_translation_info_new (append_construction_prop_from_variant_dbus_transform,
+                                                   NULL,
+                                                   NULL));
+  g_hash_table_insert (table,
+                       g_strdup ("offset"),
+                       value_translation_info_new (append_construction_prop_from_variant_dbus_transform,
+                                                   NULL,
+                                                   NULL));
+  g_hash_table_insert (table,
+                       g_strdup ("sort"),
+                       value_translation_info_new (append_construction_prop_from_variant_enum_transform,
+                                                   alloc_for_gtype (DM_TYPE_QUERY_SORT),
+                                                   g_free));
+  g_hash_table_insert (table,
+                       g_strdup ("order"),
+                       value_translation_info_new (append_construction_prop_from_variant_enum_transform,
+                                                   alloc_for_gtype (DM_TYPE_QUERY_ORDER),
+                                                   g_free));
+
+  return g_steal_pointer (&table);
+}
+
+static DmQuery *
+create_query_from_dbus_query_parameters (GVariant     *query_parameters,
+                                         const char   *application_id,
+                                         GHashTable   *translation_infos,
+                                         GError      **error)
+{
+  GVariantIter iter;
+  char *iter_key;
+  GVariant *iter_value;
+
+  g_autoptr(GArray) values_array = g_array_new (FALSE, TRUE, sizeof (GValue));
+  g_autoptr(GPtrArray) props_array = g_ptr_array_new_with_free_func (g_free);
+
+  /* Always add the app-id to the query */
+  append_construction_prop_from_string ("app-id",
+                                        application_id,
+                                        values_array,
+                                        props_array);
+
+  g_variant_iter_init (&iter, query_parameters);
+  while (g_variant_iter_next (&iter, "{sv}", &iter_key, &iter_value))
+    {
+      g_autofree char *key = iter_key;
+      g_autoptr(GVariant) variant = iter_value;
+      ValueTranslationInfo *translation_info = g_hash_table_lookup (translation_infos,
+                                                                    key);
+      
+      if (translation_info == NULL)
+        {
+          g_set_error (error,
+                       EKS_ERROR,
+                       EKS_ERROR_INVALID_REQUEST,
+                       "Invalid query parameter: %s",
+                       key);
+          return NULL;
+        }
+
+      if (!translation_info->append_func (key,
+                                          variant,
+                                          values_array,
+                                          props_array,
+                                          translation_info->user_data,
+                                          error))
+        return NULL;
+    }
+
+  return DM_QUERY (g_object_new_with_properties (DM_TYPE_QUERY,
+                                                 props_array->len,
+                                                 (const char **) props_array->pdata,
+                                                 (const GValue *) values_array->data));
+}
+
+static gboolean
+handle_query (EksContentMetadata    *skeleton,
+              GDBusMethodInvocation *invocation,
+              GVariant              *queries,
+              gpointer               user_data)
+{
+  EksMetadataProvider *self = user_data;
+  DmEngine *engine = dm_engine_get_default ();
+  g_autoptr(GError) local_error = NULL;
+  g_autoptr(DmQuery) query = NULL;
+  g_autoptr(GVariant) first_child = NULL;
+  guint n_children = g_variant_n_children (queries);
+
+  /* XXX: For now, we only support one query in the array, but the
+   * interface contract may be extended to support multiple queries. */
+  if (n_children != 1)
+    {
+      g_dbus_method_invocation_take_error (invocation,
+                                           g_error_new (G_IO_ERROR,
+                                                        G_IO_ERROR_FAILED,
+                                                        "This version of eks-search-provider "
+                                                        "can only perform one query, not %u",
+                                                        n_children));
+      return TRUE;
+    }
+
+  first_child = g_variant_get_child_value (queries, 0);
+  query =
+    create_query_from_dbus_query_parameters (first_child,
+                                             self->application_id,
+                                             self->translation_infos,
+                                             &local_error);
+
+  if (query == NULL)
+    {
+      g_dbus_method_invocation_take_error (invocation,
+                                           g_steal_pointer (&local_error));
+      return TRUE;
+    }
+
+  /* Hold the application so that it doesn't go away whilst we're handling
+   * the query */
+  g_application_hold (g_application_get_default ());
+
+  dm_engine_query (engine,
+                   query,
+                   NULL,
+                   on_received_query_results,
+                   metadata_query_state_new (self, invocation));
+  return TRUE;
+}
+
+static gboolean
+handle_shards (EksContentMetadata    *skeleton,
+               GDBusMethodInvocation *invocation,
+               gpointer               user_data)
+{
+  EksMetadataProvider *self = user_data;
+  DmEngine *engine = dm_engine_get_default ();
+  g_autoptr(GError) error = NULL;
+  DmDomain *domain = dm_engine_get_domain_for_app (engine,
+                                                   self->application_id,
+                                                   &error);
+  g_auto(GStrv) shards_strv = NULL;
+
+  if (domain == NULL)
+    {
+      g_dbus_method_invocation_take_error (invocation,
+                                           g_steal_pointer (&error));
+      return TRUE;
+    }
+
+  shards_strv = strv_from_shard_list (dm_domain_get_shards (domain));
+  eks_content_metadata_complete_shards (skeleton,
+                                        invocation,
+                                        (const char * const *) shards_strv);
+
+  return TRUE;
+}
+
+static GDBusInterfaceSkeleton *
+eks_metadata_provider_skeleton_for_interface (EksProvider *provider,
+                                              const char  *interface)
+{
+  EksMetadataProvider *self = EKS_METADATA_PROVIDER (provider);
+
+  if (g_strcmp0 (interface, "com.endlessm.ContentMetadata") == 0)
+      return G_DBUS_INTERFACE_SKELETON (self->skeleton);
+
+  g_assert_not_reached ();
+  return NULL;
+}
+
+static void
+eks_metadata_provider_interface_init (EksProviderInterface *iface)
+{
+  iface->skeleton_for_interface = eks_metadata_provider_skeleton_for_interface;
+}
+
+static void
+eks_metadata_provider_init (EksMetadataProvider *self)
+{
+  self->skeleton = eks_content_metadata_skeleton_new ();
+  self->translation_infos = article_metadata_query_construction_props_translation_table ();
+
+  g_signal_connect (self->skeleton, "handle-query",
+                    G_CALLBACK (handle_query), self);
+  g_signal_connect (self->skeleton, "handle-shards",
+                    G_CALLBACK (handle_shards), self);
+}

--- a/search-provider/eks-metadata-provider.h
+++ b/search-provider/eks-metadata-provider.h
@@ -1,0 +1,12 @@
+/* Copyright 2018 Endless Mobile, Inc. */
+
+#pragma once
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define EKS_TYPE_METADATA_PROVIDER eks_metadata_provider_get_type ()
+G_DECLARE_FINAL_TYPE (EksMetadataProvider, eks_metadata_provider, EKS, METADATA_PROVIDER, GObject)
+
+G_END_DECLS

--- a/search-provider/eks-query-util.c
+++ b/search-provider/eks-query-util.c
@@ -12,6 +12,7 @@ models_for_result (DmEngine      *engine,
                    const char    *application_id,
                    GAsyncResult  *result,
                    GSList       **models,
+                   gint          *upper_bound,
                    GError       **error)
 {
   g_autoptr(DmQueryResults) results = NULL;
@@ -23,9 +24,13 @@ models_for_result (DmEngine      *engine,
   if (domain == NULL)
       return FALSE;
 
-  *models = g_slist_copy_deep (dm_query_results_get_models (results),
-                               (GCopyFunc) g_object_ref,
-                               NULL);
+  if (models != NULL)
+    *models = g_slist_copy_deep (dm_query_results_get_models (results),
+                                 (GCopyFunc) g_object_ref,
+                                 NULL);
+
+  if (upper_bound != NULL)
+    *upper_bound = dm_query_results_get_upper_bound (results);
 
   return TRUE;
 }
@@ -36,6 +41,7 @@ models_and_shards_for_result (DmEngine    *engine,
                               GAsyncResult  *result,
                               GSList       **models,
                               GSList       **shards,
+                              gint          *upper_bound,
                               GError       **error)
 {
   g_autoptr(DmQueryResults) results = NULL;
@@ -47,12 +53,18 @@ models_and_shards_for_result (DmEngine    *engine,
   if (domain == NULL)
       return FALSE;
 
-  *shards = g_slist_copy_deep (dm_domain_get_shards (domain),
-                               (GCopyFunc) g_object_ref,
-                               NULL);
-  *models = g_slist_copy_deep (dm_query_results_get_models (results),
-                               (GCopyFunc) g_object_ref,
-                               NULL);
+  if (shards != NULL)
+    *shards = g_slist_copy_deep (dm_domain_get_shards (domain),
+                                 (GCopyFunc) g_object_ref,
+                                 NULL);
+
+  if (models != NULL)
+    *models = g_slist_copy_deep (dm_query_results_get_models (results),
+                                 (GCopyFunc) g_object_ref,
+                                 NULL);
+
+  if (upper_bound != NULL)
+    *upper_bound = dm_query_results_get_upper_bound (results);
 
   return TRUE;
 }

--- a/search-provider/eks-query-util.h
+++ b/search-provider/eks-query-util.h
@@ -11,6 +11,7 @@ gboolean models_for_result (DmEngine      *engine,
                             const gchar   *application_id,
                             GAsyncResult  *result,
                             GSList       **models,
+                            gint          *upper_bound,
                             GError       **error);
 
 gboolean models_and_shards_for_result (DmEngine      *engine,
@@ -18,6 +19,7 @@ gboolean models_and_shards_for_result (DmEngine      *engine,
                                        GAsyncResult  *result,
                                        GSList       **models,
                                        GSList       **shards,
+                                       gint          *upper_bound,
                                        GError       **error);
 
 GStrv strv_from_shard_list (GSList *string_list);

--- a/search-provider/eks-search-app.c
+++ b/search-provider/eks-search-app.c
@@ -4,6 +4,8 @@
 
 #include "eks-discovery-feed-provider-dbus.h"
 #include "eks-discovery-feed-provider.h"
+#include "eks-metadata-provider.h"
+#include "eks-metadata-provider-dbus.h"
 #include "eks-provider-iface.h"
 #include "eks-search-provider.h"
 #include "eks-search-provider-dbus.h"
@@ -26,6 +28,8 @@ struct _EksSearchApp
   GHashTable *app_search_providers;
   // Hash table with app id string keys, EksDiscoveryFeedProvider values
   GHashTable *discovery_feed_content_providers;
+  // Hash table with app id string keys, EksMetadataProvider values
+  GHashTable *metadata_providers;
 };
 
 G_DEFINE_TYPE (EksSearchApp,
@@ -40,6 +44,7 @@ eks_search_app_finalize (GObject *object)
   g_clear_object (&self->dispatcher);
   g_clear_pointer (&self->app_search_providers, g_hash_table_unref);
   g_clear_pointer (&self->discovery_feed_content_providers, g_hash_table_unref);
+  g_clear_pointer (&self->metadata_providers, g_hash_table_unref);
 
   G_OBJECT_CLASS (eks_search_app_parent_class)->finalize (object);
 }
@@ -165,6 +170,11 @@ subtree_object_info_for_interface (EksSearchApp      *self,
       info->create_type = EKS_TYPE_DISCOVERY_FEED_PROVIDER;
       info->cache = self->discovery_feed_content_providers;
     }
+  else if (g_strcmp0 (interface, "com.endlessm.ContentMetadata") == 0)
+    {
+      info->create_type = EKS_TYPE_METADATA_PROVIDER;
+      info->cache = self->metadata_providers;
+    }
   else
     g_assert_not_reached();
 }
@@ -202,6 +212,7 @@ eks_search_app_node_interface_infos ()
   g_ptr_array_add (ptr_array, eks_discovery_feed_news_interface_info ());
   g_ptr_array_add (ptr_array, eks_discovery_feed_video_interface_info ());
   g_ptr_array_add (ptr_array, eks_discovery_feed_artwork_interface_info ());
+  g_ptr_array_add (ptr_array, eks_content_metadata_interface_info ());
   return ptr_array;
 }
 
@@ -213,6 +224,7 @@ eks_search_app_init (EksSearchApp *self)
                                    NULL);
   self->app_search_providers = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
   self->discovery_feed_content_providers = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
+  self->metadata_providers = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
   g_signal_connect (self->dispatcher, "dispatch-subtree",
                     G_CALLBACK (dispatch_subtree), self);
 }


### PR DESCRIPTION
This interface mirrors a subset of what ekncontent
provides through EkncQueryObject and EkncContentObjectModel. It
should be used by applications to do a query as though they
were writing queries against ekcontent directly and needed
to get back article metadata plus a list of shards corresponding
to the returned articles.

The Query() method takes similar arguments to EkncQueryObject
through an a{sv} structure and returns a list of corresponding
shards and metadata entries.

The Shards() method just returns the shard paths for an application,
in case the consumer already knows what EKN ID they wanted to look up.

https://phabricator.endlessm.com/T20853