### PR TITLE
multi-services: Add com.endlessm.MultiEknServices multiplexer flatpak

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,107 +1,24 @@
-## Process this file with automake to produce Makefile.in
-
-# Copyright 2016 Endless Mobile, Inc.
-
-## -----------
-## Makefile.am
-## -----------
-## Please keep this file well-commented.
+# Copyright (C) 2016-2018 Endless Mobile, Inc.
+#
+# Note that this file includes Makefile.am.dbus-service.inc for the DBus Service
+# and Makefile.am.multi-services.inc for the multi-service dispatcher shim.
+#
+# We define all automake variables first and then include the parts of the
+# library that we are building.
 
 bin_PROGRAMS =
+servicedir = $(datadir)/dbus-1/services
+service_DATA =
+BUILT_SOURCES =
 CLEANFILES =
 MAINTAINERCLEANFILES = $(GITIGNORE_MAINTAINERCLEANFILES_TOPLEVEL)
 EXTRA_DIST =
 
-# # # SUBSTITUTED FILES # # #
-# These files need to be filled in with make variables
 do_subst = $(SED) -e 's|%bindir%|$(bindir)|g'
-subst_files = \
-	search-provider/com.endlessm.EknServices2.SearchProviderV2.service \
-	$(NULL)
+subst_files =
 
-$(subst_files): %: %.in Makefile
-	$(AM_V_GEN)$(MKDIR_P) $(@D) && \
-	$(do_subst) $< > $@
-
-CLEANFILES += $(subst_files)
-EXTRA_DIST += $(patsubst %,%.in,$(subst_files))
-
-# # # DBUS SERVICES # # #
-servicedir = $(datadir)/dbus-1/services
-service_DATA = \
-	search-provider/com.endlessm.EknServices2.SearchProviderV2.service \
-	$(NULL)
-
-search-provider/eks-search-provider-dbus.h search-provider/eks-search-provider-dbus.c: search-provider/eks-search-provider-dbus.xml Makefile.am
-	$(AM_V_GEN) $(MKDIR_P) $(@D) && \
-	$(GDBUS_CODEGEN) \
-	--interface-prefix=org.gnome.Shell \
-	--c-namespace Eks \
-	--generate-c-code search-provider/eks-search-provider-dbus \
-	$<
-
-search-provider/eks-discovery-feed-provider-dbus.h search-provider/eks-discovery-feed-provider-dbus.c: search-provider/eks-discovery-feed-provider-dbus.xml Makefile.am
-	$(AM_V_GEN) $(MKDIR_P) $(@D) && \
-	$(GDBUS_CODEGEN) \
-	--interface-prefix=com.endlessm. \
-	--c-namespace Eks \
-	--generate-c-code search-provider/eks-discovery-feed-provider-dbus \
-	$<
-
-search-provider/eks-knowledge-app-dbus.h search-provider/eks-knowledge-app-dbus.c: search-provider/eks-knowledge-app-dbus.xml Makefile.am
-	$(AM_V_GEN) $(MKDIR_P) $(@D) && \
-	$(GDBUS_CODEGEN) \
-	--interface-prefix=com.endlessm. \
-	--c-namespace Eks \
-	--generate-c-code search-provider/eks-knowledge-app-dbus \
-	$<
-
-EXTRA_DIST += \
-	search-provider/eks-search-provider-dbus.xml \
-	search-provider/eks-discovery-feed-provider-dbus.xml \
-	search-provider/eks-knowledge-app-dbus.xml \
-	$(NULL)
-
-BUILT_SOURCES = \
-	search-provider/eks-search-provider-dbus.h \
-	search-provider/eks-search-provider-dbus.c \
-	search-provider/eks-discovery-feed-provider-dbus.h \
-	search-provider/eks-discovery-feed-provider-dbus.c \
-	search-provider/eks-knowledge-app-dbus.h \
-	search-provider/eks-knowledge-app-dbus.c \
-	$(NULL)
-
-eks_search_provider_v2_SOURCES = \
-	search-provider/eks-discovery-feed-provider.c \
-	search-provider/eks-discovery-feed-provider.h \
-	search-provider/eks-discovery-feed-provider-dbus.c \
-	search-provider/eks-discovery-feed-provider-dbus.h \
-	search-provider/eks-knowledge-app-dbus.c \
-	search-provider/eks-knowledge-app-dbus.h \
-	search-provider/eks-provider-iface.h \
-	search-provider/eks-provider-iface.c \
-	search-provider/eks-search-app.c \
-	search-provider/eks-search-app.h \
-	search-provider/eks-search-main.c \
-	search-provider/eks-search-provider-dbus.c \
-	search-provider/eks-search-provider-dbus.h \
-	search-provider/eks-search-provider.c \
-	search-provider/eks-search-provider.h \
-	search-provider/eks-subtree-dispatcher.c \
-	search-provider/eks-subtree-dispatcher.h \
-	$(NULL)
-eks_search_provider_v2_CFLAGS = \
-	@SEARCH_PROVIDER_CFLAGS@ \
-	-I $(builddir)/search-provider \
-	$(AM_CFLAGS) \
-	$(NULL)
-eks_search_provider_v2_LDADD = \
-	@SEARCH_PROVIDER_LIBS@ \
-	$(NULL)
-
-# # # BINARIES # # #
-bin_PROGRAMS += \
-	eks-search-provider-v2 \
-	$(NULL)
+include $(top_srcdir)/Makefile.am.dbus-service.inc
+include $(top_srcdir)/Makefile.am.multi-services.inc
 
 -include $(top_srcdir)/git.mk
+

--- a/Makefile.am.dbus-service.inc
+++ b/Makefile.am.dbus-service.inc
@@ -1,0 +1,82 @@
+# Copyright 2016-2018 Endless Mobile, Inc.
+
+if EOS_KNOWLEDGE_SERVICES_DBUS_SERVICE_ENABLED
+## -----------
+## Makefile.am
+## -----------
+## Please keep this file well-commented.
+
+# # # DBUS SERVICES # # #
+search-provider/eks-search-provider-dbus.h search-provider/eks-search-provider-dbus.c: search-provider/eks-search-provider-dbus.xml Makefile.am
+	$(AM_V_GEN) $(MKDIR_P) $(@D) && \
+	$(GDBUS_CODEGEN) \
+	--interface-prefix=org.gnome.Shell \
+	--c-namespace Eks \
+	--generate-c-code search-provider/eks-search-provider-dbus \
+	$<
+
+search-provider/eks-discovery-feed-provider-dbus.h search-provider/eks-discovery-feed-provider-dbus.c: search-provider/eks-discovery-feed-provider-dbus.xml Makefile.am
+	$(AM_V_GEN) $(MKDIR_P) $(@D) && \
+	$(GDBUS_CODEGEN) \
+	--interface-prefix=com.endlessm. \
+	--c-namespace Eks \
+	--generate-c-code search-provider/eks-discovery-feed-provider-dbus \
+	$<
+
+search-provider/eks-knowledge-app-dbus.h search-provider/eks-knowledge-app-dbus.c: search-provider/eks-knowledge-app-dbus.xml Makefile.am
+	$(AM_V_GEN) $(MKDIR_P) $(@D) && \
+	$(GDBUS_CODEGEN) \
+	--interface-prefix=com.endlessm. \
+	--c-namespace Eks \
+	--generate-c-code search-provider/eks-knowledge-app-dbus \
+	$<
+
+EXTRA_DIST += \
+	search-provider/eks-search-provider-dbus.xml \
+	search-provider/eks-discovery-feed-provider-dbus.xml \
+	search-provider/eks-knowledge-app-dbus.xml \
+	$(NULL)
+
+BUILT_SOURCES += \
+	search-provider/eks-search-provider-dbus.h \
+	search-provider/eks-search-provider-dbus.c \
+	search-provider/eks-discovery-feed-provider-dbus.h \
+	search-provider/eks-discovery-feed-provider-dbus.c \
+	search-provider/eks-knowledge-app-dbus.h \
+	search-provider/eks-knowledge-app-dbus.c \
+	$(NULL)
+
+eks_search_provider_v2_SOURCES = \
+	search-provider/eks-discovery-feed-provider.c \
+	search-provider/eks-discovery-feed-provider.h \
+	search-provider/eks-discovery-feed-provider-dbus.c \
+	search-provider/eks-discovery-feed-provider-dbus.h \
+	search-provider/eks-knowledge-app-dbus.c \
+	search-provider/eks-knowledge-app-dbus.h \
+	search-provider/eks-provider-iface.h \
+	search-provider/eks-provider-iface.c \
+	search-provider/eks-search-app.c \
+	search-provider/eks-search-app.h \
+	search-provider/eks-search-main.c \
+	search-provider/eks-search-provider-dbus.c \
+	search-provider/eks-search-provider-dbus.h \
+	search-provider/eks-search-provider.c \
+	search-provider/eks-search-provider.h \
+	search-provider/eks-subtree-dispatcher.c \
+	search-provider/eks-subtree-dispatcher.h \
+	$(NULL)
+eks_search_provider_v2_CFLAGS = \
+	@SEARCH_PROVIDER_CFLAGS@ \
+	-I $(builddir)/search-provider \
+	$(AM_CFLAGS) \
+	$(NULL)
+eks_search_provider_v2_LDADD = \
+	@SEARCH_PROVIDER_LIBS@ \
+	$(NULL)
+
+# # # BINARIES # # #
+bin_PROGRAMS += \
+	eks-search-provider-v2 \
+	$(NULL)
+
+endif

--- a/Makefile.am.multi-services.inc
+++ b/Makefile.am.multi-services.inc
@@ -1,0 +1,38 @@
+# Copyright 2016-2018 Endless Mobile, Inc.
+
+if EOS_KNOWLEDGE_SERVICES_MULTI_SERVICES_ENABLED
+
+bin_PROGRAMS += eks-multi-services-dispatcher
+
+# # # SUBSTITUTED FILES # # #
+# These files need to be filled in with make variables
+subst_files += \
+	search-provider/com.endlessm.EknServices.SearchProviderV1.service \
+	search-provider/com.endlessm.EknServices2.SearchProviderV2.service \
+	$(NULL)
+
+$(subst_files): %: %.in Makefile
+	$(AM_V_GEN)$(MKDIR_P) $(@D) && \
+	$(do_subst) $< > $@
+
+CLEANFILES += $(subst_files)
+EXTRA_DIST += $(patsubst %,%.in,$(subst_files))
+
+eks_multi_services_dispatcher_SOURCES = \
+	multi-services/eks-multi-services-dispatcher.c \
+	$(NULL)
+eks_multi_services_dispatcher_CFLAGS = \
+	@MULTI_SERVICES_CFLAGS@ \
+	-I $(builddir)/multi-services \
+	$(AM_CFLAGS) \
+	$(NULL)
+eks_multi_services_dispatcher_LDADD = \
+	@MULTI_SERVICES_LIBS@ \
+	$(NULL)
+
+service_DATA += \
+	search-provider/com.endlessm.EknServices.SearchProviderV1.service \
+	search-provider/com.endlessm.EknServices2.SearchProviderV2.service \
+	$(NULL)
+
+endif

--- a/com.endlessm.MultiEknServices.json.in
+++ b/com.endlessm.MultiEknServices.json.in
@@ -1,0 +1,84 @@
+{
+    "app-id": "com.endlessm.MultiEknServices",
+    "branch": "@BRANCH@",
+    "runtime": "com.endlessm.apps.Platform",
+    "runtime-version": "3",
+    "sdk": "com.endlessm.apps.Sdk",
+    "finish-args": [
+        "--filesystem=/var/lib/flatpak:ro",
+        "--filesystem=/var/endless-extra/flatpak:ro",
+        "--filesystem=~/.local/share/flatpak:ro",
+        "--share=network",
+        "--socket=session-bus"
+    ],
+    "add-extensions": {
+        "com.endlessm.Platform": {
+            "directory": "sdk/0",
+            "no-autodownload": true,
+            "versions": "eos3.2;eos3.1;eos3.0"
+        },
+        "com.endlessm.apps.Platform@1": {
+            "directory": "sdk/1",
+            "no-autodownload": true,
+            "version": "1"
+        },
+        "com.endlessm.apps.Platform@2": {
+            "directory": "sdk/2",
+            "no-autodownload": true,
+            "version": "2"
+        },
+        "com.endlessm.apps.Platform@3": {
+            "directory": "sdk/3",
+            "no-autodownload": true,
+            "version": "3"
+        }
+    },
+    "modules": [
+        {
+            "name": "eos-knowledge-services-multiplexer",
+            "config-opts": [
+                "--enable-multi-services",
+                "--disable-dbus-service"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "path": ".",
+                    "branch": "@GIT_CLONE_BRANCH@"
+                }
+            ]
+        },
+        {
+            "name": "eos-knowledge-services-v1",
+            "config-opts": ["--prefix=/app/eos-knowledge-services/1"],
+            "sources": [
+                {
+                    "type": "git",
+                    "path": ".",
+                    "branch": "origin/eos3"
+                }
+            ]
+        },
+        {
+            "name": "eos-knowledge-services-v2",
+            "config-opts": ["--prefix=/app/eos-knowledge-services/2"],
+            "sources": [
+                {
+                    "type": "git",
+                    "path": ".",
+                    "branch": "origin/master"
+                }
+            ]
+        },
+        {
+            "name": "multi-eos-knowledge-services-directories",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p /app/sdk/0",
+                "mkdir -p /app/sdk/1",
+                "mkdir -p /app/sdk/2",
+                "mkdir -p /app/sdk/3"
+            ]
+        }
+    ]
+}

--- a/configure.ac
+++ b/configure.ac
@@ -36,15 +36,42 @@ AC_PROG_CC
 AC_PROG_CC_C99
 # Library configuration tool
 PKG_PROG_PKG_CONFIG
-# Needed for implementing dbus interfaces in C
-AC_SUBST([GDBUS_CODEGEN], [`$PKG_CONFIG --variable gdbus_codegen gio-2.0`])
+
+# Whether or not to build the multiple-SDK-compatibility shim too
+AC_ARG_ENABLE([dbus-service], [dbus service], [
+  EOS_KNOWLEDGE_SERVICES_DBUS_SERVICE_ENABLED=$enableval
+], [
+  EOS_KNOWLEDGE_SERVICES_DBUS_SERVICE_ENABLED=yes
+])
+AM_CONDITIONAL([EOS_KNOWLEDGE_SERVICES_DBUS_SERVICE_ENABLED], [test "x$EOS_KNOWLEDGE_SERVICES_DBUS_SERVICE_ENABLED" = "xyes"])
+
+AC_ARG_ENABLE([multi-services], [multiple SDK multiplexer], [
+  EOS_KNOWLEDGE_SERVICES_MULTI_SERVICES_ENABLED=$enableval
+], [
+  EOS_KNOWLEDGE_SERVICES_MULTI_SERVICES_ENABLED=no
+])
+AM_CONDITIONAL([EOS_KNOWLEDGE_SERVICES_MULTI_SERVICES_ENABLED], [test "x$EOS_KNOWLEDGE_SERVICES_MULTI_SERVICES_ENABLED" = "xyes"])
 
 # We need the eos-knowledge-content library
-PKG_CHECK_MODULES([SEARCH_PROVIDER], [
-    eos-knowledge-content-0
-    gio-2.0
-    glib-2.0
-    gobject-2.0
+AS_IF([test "x$EOS_KNOWLEDGE_SERVICES_DBUS_SERVICE_ENABLED" = "xyes"], [
+  # Needed for implementing dbus interfaces in C
+  AC_SUBST([GDBUS_CODEGEN], [`$PKG_CONFIG --variable gdbus_codegen gio-2.0`])
+
+  PKG_CHECK_MODULES([SEARCH_PROVIDER], [
+      eos-knowledge-content-0
+      gio-2.0
+      glib-2.0
+      gobject-2.0
+  ])
+])
+
+# Only need glib and gio for the multi-services binary
+AS_IF([test "x$EOS_KNOWLEDGE_SERVICES_MULTI_SERVICES_ENABLED" = "xyes"], [
+  PKG_CHECK_MODULES([MULTI_SERVICES], [
+      gio-2.0
+      glib-2.0
+      gobject-2.0
+  ])
 ])
 
 AC_CACHE_SAVE

--- a/multi-services/eks-multi-services-dispatcher.c
+++ b/multi-services/eks-multi-services-dispatcher.c
@@ -1,0 +1,166 @@
+/* Copyright 2016 Endless Mobile, Inc. */
+
+#include <gio/gio.h>
+#include <glib.h>
+
+#include <string.h>
+
+static char *services_version;
+
+static GOptionEntry entries[] = {
+  { "services-version", 's', 0, G_OPTION_ARG_STRING, &services_version, "The eks-search-provider version to use", "VERSION" },
+  { NULL }
+};
+
+static GStrv
+envp_search (GStrv       envp,
+             const char *variable)
+{
+  gsize variable_len = strlen (variable);
+
+  for (; *envp != NULL; ++envp)
+    {
+      if (strncmp (*envp, variable, variable_len) == 0)
+        return envp;
+    }
+
+  return NULL;
+}
+
+static void
+insert_paths_to_env_var (GStrv               env,
+                         const char         *variable,
+                         const char * const *paths)
+{
+  GStrv envp_index = envp_search (env, variable);
+  g_autofree char *join_envp = NULL;
+
+  if (envp_index == NULL)
+    return;
+
+  join_envp = g_strjoinv (":", (GStrv) paths);
+
+  /* Free the string already at envp_index */
+  g_free (*envp_index);
+
+  *envp_index = g_strdup_printf ("%s=%s", variable, join_envp);
+}
+
+static GSubprocess *
+spawnv_with_appended_paths_and_fds (const char * const  *argv,
+                                    const char * const  *executable_paths,
+                                    const char * const  *ld_library_paths,
+                                    const char * const  *xdg_data_dirs,
+                                    GError             **error)
+{
+  g_autoptr(GSubprocessLauncher) launcher = g_subprocess_launcher_new (G_SUBPROCESS_FLAGS_INHERIT_FDS);
+  g_auto(GStrv) env = g_listenv ();
+
+  insert_paths_to_env_var (env, "PATH", executable_paths);
+  insert_paths_to_env_var (env, "LD_LIBRARY_PATH", ld_library_paths);
+  insert_paths_to_env_var (env, "XDG_DATA_DIRS", xdg_data_dirs);
+
+  return g_subprocess_launcher_spawnv (launcher, argv, error); 
+}
+
+static gboolean
+dispatch_correct_service (const char  *services_version,
+                          GError      **error)
+{
+  /* We keep track of this and then free it, the exec'd service
+   * will become a child of init and inherit all our fds, thus
+   * consuming the d-bus traffic that was destined for this process. */
+  g_autoptr(GSubprocess) subprocess = NULL;
+
+  if (g_strcmp0 (services_version, "1") == 0)
+    {
+      const char * const argv[] = {
+        "/app/eos-knowledge-services/1/bin/eks-search-provider-v1",
+        NULL
+      };
+      const char * const executable_paths[] = {
+        "/app/sdk/1/bin",
+        "/app/eos-knowledge-services/1/bin",
+        NULL
+      };
+      const char * const ld_library_paths[] = {
+        "/app/sdk/1/lib",
+        "/app/eos-knowledge-services/1/lib",
+        NULL
+      };
+      const char * const xdg_data_dirs[] = {
+        "/app/sdk/1/share",
+        "/app/eos-knowledge-services/1/share",
+        NULL
+      };
+
+      subprocess = spawnv_with_appended_paths_and_fds (argv,
+                                                       executable_paths,
+                                                       ld_library_paths,
+                                                       xdg_data_dirs,
+                                                       error);
+      return subprocess != NULL;
+    }
+  else if (g_strcmp0 (services_version, "2") == 0)
+    {
+      const char * argv[] = {
+        "/app/eos-knowledge-services/2/bin/eks-search-provider-v2",
+        NULL
+      };
+      const char * executable_paths[] = {
+        "/app/sdk/3/bin",
+        "/app/eos-knowledge-services/2/bin",
+        NULL
+      };
+      const char * ld_library_paths[] = {
+        "/app/sdk/3/lib",
+        "/app/eos-knowledge-services/2/lib",
+        NULL
+      };
+      const char * xdg_data_dirs[] = {
+        "/app/sdk/3/share",
+        "/app/eos-knowledge-services/2/share",
+        NULL
+      };
+
+      subprocess = spawnv_with_appended_paths_and_fds (argv,
+                                                       executable_paths,
+                                                       ld_library_paths,
+                                                       xdg_data_dirs,
+                                                       error);
+      return subprocess != NULL;
+    }
+
+  g_set_error (error,
+               G_IO_ERROR,
+               G_IO_ERROR_FAILED,
+               "Don't know how to spawn services version %s",
+               services_version);
+  return FALSE;
+}
+
+int
+main (int    argc,
+      char **argv)
+{
+  g_autoptr(GError) local_error = NULL;
+  g_autoptr(GOptionContext) context = g_option_context_new ("- multiplexer for EknServices");
+
+  g_option_context_add_main_entries (context, entries, NULL);
+
+  if (!g_option_context_parse (context, &argc, &argv, &local_error))
+    {
+      g_message ("Option parsing failed: %s\n", local_error->message);
+      return 1;
+    }
+
+  if (!dispatch_correct_service (services_version, &local_error))
+    {
+      g_message ("Failed to dispatch correct service for version %s: %s",
+                 services_version,
+                 local_error->message);
+      return 1;
+    }
+
+  return 0;
+}

--- a/search-provider/com.endlessm.EknServices.SearchProviderV1.service.in
+++ b/search-provider/com.endlessm.EknServices.SearchProviderV1.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=com.endlessm.EknServices2.SearchProviderV1
+Exec=%bindir%/eks-multi-services-dispatcher --services-version 1

--- a/search-provider/com.endlessm.EknServices2.SearchProviderV2.service.in
+++ b/search-provider/com.endlessm.EknServices2.SearchProviderV2.service.in
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.endlessm.EknServices2.SearchProviderV2
-Exec=%bindir%/eks-search-provider-v2
+Exec=%bindir%/eks-multi-services-dispatcher --services-version 2


### PR DESCRIPTION
This flatpak mounts all the SDKs as extensions and installs each
knowledge-services version to /app/eos-knowledge-services/1,
/app/eos-knowledge-services/2 etc.

It then registers D-Bus services for com.endlessm.EknServices.SearchProviderV1
and com.endlessm.EknServices2.SearchProviderV2 which both point to
eks-multi-services-dispatcher (using --services-version to indicate
which search provider version to use).

When invoked, the multiplexer sets LD_LIBRARY_PATH, XDG_DATA_DIRS and PATH
to the appropriate mounted SDK and eos-knowledge-services version and
spawns it, inheriting the parent file descriptors. Then from there, the
child process can take over, take ownership of the name and process
any incoming messages.

https://phabricator.endlessm.com/T20853