### PR TITLE
Port to DModel

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,9 +39,8 @@ PKG_PROG_PKG_CONFIG
 # Needed for implementing dbus interfaces in C
 AC_SUBST([GDBUS_CODEGEN], [`$PKG_CONFIG --variable gdbus_codegen gio-2.0`])
 
-# We need the eos-knowledge-content library
 PKG_CHECK_MODULES([SEARCH_PROVIDER], [
-    eos-knowledge-content-0
+    dmodel-0
     gio-2.0
     glib-2.0
     gobject-2.0

--- a/search-provider/eks-errors.c
+++ b/search-provider/eks-errors.c
@@ -1,8 +1,7 @@
 /* Copyright 2018 Endless Mobile, Inc. */
 
+#include <dmodel.h>
 #include <gio/gio.h>
-
-#include <eos-knowledge-content.h>
 
 #include "eks-errors.h"
 
@@ -10,45 +9,39 @@ GError *
 eks_map_error_to_eks_error (const GError *error)
 {
   if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND) ||
-      g_error_matches (error, EKNC_DOMAIN_ERROR, EKNC_DOMAIN_ERROR_PATH_NOT_FOUND))
+      g_error_matches (error, DM_DOMAIN_ERROR, DM_DOMAIN_ERROR_PATH_NOT_FOUND))
     {
       return g_error_new (EKS_ERROR,
                           EKS_ERROR_APP_NOT_FOUND,
                           error->message);
     }
-  else if (g_error_matches (error,
-                            EKNC_DOMAIN_ERROR,
-                            EKNC_DOMAIN_ERROR_UNSUPPORTED_VERSION))
+  else if (g_error_matches (error, DM_DOMAIN_ERROR,
+                            DM_DOMAIN_ERROR_UNSUPPORTED_VERSION))
     {
       return g_error_new (EKS_ERROR,
                           EKS_ERROR_UNSUPPORTED_VERSION,
                           error->message);
     }
-  else if (g_error_matches (error,
-                            EKNC_DOMAIN_ERROR,
-                            EKNC_DOMAIN_ERROR_ID_NOT_FOUND))
+  else if (g_error_matches (error, DM_DOMAIN_ERROR,
+                            DM_DOMAIN_ERROR_ID_NOT_FOUND))
     {
       return g_error_new (EKS_ERROR,
                           EKS_ERROR_ID_NOT_FOUND,
                           error->message);
     }
-  else if (g_error_matches (error,
-                            EKNC_DOMAIN_ERROR,
-                            EKNC_DOMAIN_ERROR_ID_NOT_VALID))
+  else if (g_error_matches (error, DM_DOMAIN_ERROR,
+                            DM_DOMAIN_ERROR_ID_NOT_VALID))
     {
       return g_error_new (EKS_ERROR,
                           EKS_ERROR_INVALID_REQUEST,
                           error->message);
     }
-  else if (g_error_matches (error,
-                            EKNC_DOMAIN_ERROR,
-                            EKNC_DOMAIN_ERROR_BAD_MANIFEST) ||
-           g_error_matches (error,
-                            EKNC_DOMAIN_ERROR,
-                            EKNC_DOMAIN_ERROR_BAD_RESULTS) ||
-           g_error_matches (error,
-                            EKNC_DOMAIN_ERROR,
-                            EKNC_DOMAIN_ERROR_EMPTY))
+  else if (g_error_matches (error, DM_DOMAIN_ERROR,
+                            DM_DOMAIN_ERROR_BAD_MANIFEST) ||
+           g_error_matches (error, DM_DOMAIN_ERROR,
+                            DM_DOMAIN_ERROR_BAD_RESULTS) ||
+           g_error_matches (error, DM_DOMAIN_ERROR,
+                            DM_DOMAIN_ERROR_EMPTY))
     {
       return g_error_new (EKS_ERROR,
                           EKS_ERROR_MALFORMED_APP,

--- a/search-provider/eks-query-util.c
+++ b/search-provider/eks-query-util.c
@@ -2,29 +2,28 @@
 
 #include "eks-query-util.h"
 
-#include <eos-knowledge-content.h>
+#include <dmodel.h>
 #include <eos-shard/eos-shard-shard-file.h>
 
 #include <gio/gio.h>
 
 gboolean
-models_for_result (EkncEngine    *engine,
+models_for_result (DmEngine      *engine,
                    const char    *application_id,
                    GAsyncResult  *result,
                    GSList       **models,
                    GError       **error)
 {
-  g_autoptr(EkncQueryResults) results = NULL;
-  if (!(results = eknc_engine_query_finish (engine, result, error)))
+  g_autoptr(DmQueryResults) results = NULL;
+  if (!(results = dm_engine_query_finish (engine, result, error)))
       return FALSE;
 
-  EkncDomain *domain = eknc_engine_get_domain_for_app (engine,
-                                                       application_id,
-                                                       error);
+  DmDomain *domain = dm_engine_get_domain_for_app (engine, application_id,
+                                                   error);
   if (domain == NULL)
       return FALSE;
 
-  *models = g_slist_copy_deep (eknc_query_results_get_models (results),
+  *models = g_slist_copy_deep (dm_query_results_get_models (results),
                                (GCopyFunc) g_object_ref,
                                NULL);
 
@@ -32,27 +31,26 @@ models_for_result (EkncEngine    *engine,
 }
 
 gboolean
-models_and_shards_for_result (EkncEngine    *engine,
+models_and_shards_for_result (DmEngine    *engine,
                               const char    *application_id,
                               GAsyncResult  *result,
                               GSList       **models,
                               GSList       **shards,
                               GError       **error)
 {
-  g_autoptr(EkncQueryResults) results = NULL;
-  if (!(results = eknc_engine_query_finish (engine, result, error)))
+  g_autoptr(DmQueryResults) results = NULL;
+  if (!(results = dm_engine_query_finish (engine, result, error)))
       return FALSE;
 
-  EkncDomain *domain = eknc_engine_get_domain_for_app (engine,
-                                                       application_id,
-                                                       error);
+  DmDomain *domain = dm_engine_get_domain_for_app (engine, application_id,
+                                                   error);
   if (domain == NULL)
       return FALSE;
 
-  *shards = g_slist_copy_deep (eknc_domain_get_shards (domain),
+  *shards = g_slist_copy_deep (dm_domain_get_shards (domain),
                                (GCopyFunc) g_object_ref,
                                NULL);
-  *models = g_slist_copy_deep (eknc_query_results_get_models (results),
+  *models = g_slist_copy_deep (dm_query_results_get_models (results),
                                (GCopyFunc) g_object_ref,
                                NULL);
 

--- a/search-provider/eks-query-util.h
+++ b/search-provider/eks-query-util.h
@@ -2,18 +2,18 @@
 
 #pragma once
 
-#include <eos-knowledge-content.h>
+#include <dmodel.h>
 #include <eos-shard/eos-shard-shard-file.h>
 
 #include <gio/gio.h>
 
-gboolean models_for_result (EkncEngine    *engine,
+gboolean models_for_result (DmEngine      *engine,
                             const gchar   *application_id,
                             GAsyncResult  *result,
                             GSList       **models,
                             GError       **error);
 
-gboolean models_and_shards_for_result (EkncEngine    *engine,
+gboolean models_and_shards_for_result (DmEngine      *engine,
                                        const gchar   *application_id,
                                        GAsyncResult  *result,
                                        GSList       **models,


### PR DESCRIPTION
DModel is a standalone library that replaces the previously private
library EosKnowledgeContent. The API is essentially the same but just
requires some renames.

https://phabricator.endlessm.com/T21655