### PR TITLE
flatpak: Make com.endlessm.EknServices2.Extension extension

### DIFF
--- a/com.endlessm.EknServices.json.in
+++ b/com.endlessm.EknServices.json.in
@@ -11,6 +11,14 @@
         "--share=network",
         "--socket=session-bus"
     ],
+    "add-extensions": {
+        "com.endlessm.EknServices2.Extension": {
+            "directory": "build/eos-knowledge-services/2",
+            "bundle": true,
+            "autodelete": true,
+            "no-autodownload": true
+        }
+    },
     "modules": [
         {
             "name": "eos-knowledge-services",
@@ -20,6 +28,16 @@
                     "path": ".",
                     "branch": "@GIT_CLONE_BRANCH@"
                 }
+            ]
+        },
+        {
+            "name": "eos-knowledge-services-extension",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p /app/build/eos-knowledge-services/2",
+                "cp -r /app/bin /app/build/eos-knowledge-services/2",
+                "cp -r /app/lib /app/build/eos-knowledge-services/2",
+                "cp -r /app/share /app/build/eos-knowledge-services/2"
             ]
         }
     ]


### PR DESCRIPTION
We'll use this later in BaseEknServicesMultiplexer in order to pull in
EknServices2 as an extension

https://phabricator.endlessm.com/T21822