### PR TITLE
Update to new DModel API: ekn_id -> id

### DIFF
--- a/search-provider/eks-discovery-feed-provider.c
+++ b/search-provider/eks-discovery-feed-provider.c
@@ -176,10 +176,24 @@ add_key_value_pair_from_model_to_variant (DmContent       *model,
                                           GVariantBuilder *builder,
                                           const char      *key)
 {
+  /* Warn if code should use add_id_from_model_to_variant() instead */
+  g_return_if_fail (strcmp (key, "id") != 0);
+
   g_autofree gchar *value = NULL;
   g_autofree gchar *underscore_key = underscorify (key);
   g_object_get (model, key, &value, NULL);
   add_key_value_pair_to_variant (builder, underscore_key, value);
+}
+
+/* For API compatibility, bridge mismatch between ekn_id and #DmContent:id.
+ * Remove this when bumping the API version and just use "id". */
+static void
+add_id_from_model_to_variant (DmContent       *model,
+                              GVariantBuilder *builder)
+{
+  g_autofree char *value = NULL;
+  g_object_get (model, "id", &value, NULL);
+  add_key_value_pair_to_variant (builder, "ekn_id", value);
 }
 
 static void
@@ -422,11 +436,11 @@ artwork_card_descriptions_cb (GObject *source,
       DmContent *model = l->data;
       DiscoveryFeedCustomProps flags = DISCOVERY_FEED_NO_CUSTOM_PROPS;
 
+      add_id_from_model_to_variant (model, &builder);
       add_key_value_pair_from_model_to_variant (model, &builder, "title");
       add_key_value_pair_from_model_to_variant (model, &builder, "synopsis");
       add_key_value_pair_from_model_to_variant (model, &builder, "last-modified-date");
       add_key_value_pair_from_model_to_variant (model, &builder, "thumbnail-uri");
-      add_key_value_pair_from_model_to_variant (model, &builder, "ekn-id");
       add_first_string_value_from_model_to_variant (model, &builder, "authors", "author");
       add_first_string_value_from_model_to_variant (model, &builder, "temporal-coverage", "first-date");
 
@@ -548,9 +562,9 @@ content_article_card_descriptions_cb (GObject *source,
           add_key_value_pair_from_model_to_variant (model, &builder, "synopsis");
         }
 
+      add_id_from_model_to_variant (model, &builder);
       add_key_value_pair_from_model_to_variant (model, &builder, "last-modified-date");
       add_key_value_pair_from_model_to_variant (model, &builder, "thumbnail-uri");
-      add_key_value_pair_from_model_to_variant (model, &builder, "ekn-id");
 
       /* Stop building object */
       g_variant_builder_close (&builder);
@@ -629,10 +643,10 @@ get_word_of_the_day_content_cb (GObject *source,
 
   DmContent *model = g_slist_nth (models, 0)->data;
 
+  add_id_from_model_to_variant (model, &builder);
   add_key_value_pair_from_model_to_variant (model, &builder, "word");
   add_key_value_pair_from_model_to_variant (model, &builder, "definition");
   add_key_value_pair_from_model_to_variant (model, &builder, "part-of-speech");
-  add_key_value_pair_from_model_to_variant (model, &builder, "ekn-id");
 
   eks_discovery_feed_word_complete_get_word_of_the_day (state->provider->word_skeleton,
                                                         state->invocation,
@@ -702,9 +716,9 @@ get_quote_of_the_day_content_cb (GObject *source,
 
   DmContent *model = g_slist_nth (models, 0)->data;
 
+  add_id_from_model_to_variant (model, &builder);
   add_key_value_pair_from_model_to_variant (model, &builder, "title");
   add_first_string_value_from_model_to_variant (model, &builder, "authors", "author");
-  add_key_value_pair_from_model_to_variant (model, &builder, "ekn-id");
 
   eks_discovery_feed_quote_complete_get_quote_of_the_day (state->provider->quote_skeleton,
                                                           state->invocation,
@@ -785,11 +799,11 @@ recent_news_articles_cb (GObject *source,
 
       DmContent *model = l->data;
 
+      add_id_from_model_to_variant (model, &builder);
       add_key_value_pair_from_model_to_variant (model, &builder, "title");
       add_key_value_pair_from_model_to_variant (model, &builder, "synopsis");
       add_key_value_pair_from_model_to_variant (model, &builder, "last-modified-date");
       add_key_value_pair_from_model_to_variant (model, &builder, "thumbnail-uri");
-      add_key_value_pair_from_model_to_variant (model, &builder, "ekn-id");
 
       /* Stop building object */
       g_variant_builder_close (&builder);
@@ -876,10 +890,10 @@ relevant_video_cb (GObject *source,
 
       DmContent *model = l->data;
 
+      add_id_from_model_to_variant (model, &builder);
       add_key_value_pair_from_model_to_variant (model, &builder, "title");
       add_key_value_int_to_str_pair_from_model_to_variant (model, &builder, "duration");
       add_key_value_pair_from_model_to_variant (model, &builder, "thumbnail-uri");
-      add_key_value_pair_from_model_to_variant (model, &builder, "ekn-id");
 
       /* Stop building object */
       g_variant_builder_close (&builder);

--- a/search-provider/eks-errors.h
+++ b/search-provider/eks-errors.h
@@ -10,9 +10,9 @@ G_BEGIN_DECLS
  * EksError:
  * @EKS_ERROR_APP_NOT_FOUND: App or app file was not found
  * @EKS_ERROR_UNSUPPORTED_VERSION: Unsupported version of content found
- * @EKS_ERROR_ID_NOT_FOUND: Requested ekn id object not found
+ * @EKS_ERROR_ID_NOT_FOUND: Requested ID not found
  * @EKS_ERROR_MALFORMED_APP: App was not well-formed
- * @EKS_ERROR_INVALID_REQUEST: Caller made an malformed request
+ * @EKS_ERROR_INVALID_REQUEST: Caller made a malformed request
  *
  * Error enumeration for domain related errors.
  */

--- a/search-provider/eks-metadata-provider-dbus.xml
+++ b/search-provider/eks-metadata-provider-dbus.xml
@@ -102,12 +102,11 @@
                  "original_uri": The URI that this content was sourced from.
                  "license": License for this content.
                  "copyright_holder": Who holds the copyright for this content.
-                 "thumbnail_uri": An EKN ID specifying the location in one
-                                  of the returned shards where data for
-                                  the thumbnail for this content is stored.
-                 "ekn_id": An EKN ID specifying the location in one of the
-                           returned shards where data for this content is
-                           stored.
+                 "thumbnail_uri": An ID specifying the location in one of the
+                                  returned shards where data for the thumbnail
+                                  for this content is stored.
+                 "id": An ID specifying the location in one of the returned
+                       shards where data for this content is stored.
                  "child_tags": If this content object model represents a
                                set, the tags which should be queried as part
                                of "tags-match-any" in Query above to find
@@ -128,8 +127,8 @@
         Shards:
         Just return the location for the shards for this app without running
         a query against its database. This is useful if the caller already
-        knows an EKN ID that they need to look up for an app and just needs
-        to know where its shard file is.
+        knows an ID that they need to look up for an app and just needs to know
+        where its shard file is.
 
         Returns @Shards: an array of strings with file paths for where the shard
                          packfiles for this app are stored.

--- a/search-provider/eks-metadata-provider.c
+++ b/search-provider/eks-metadata-provider.c
@@ -221,7 +221,7 @@ static const ModelVariantTypes model_variant_types[] = {
   { "content_type", G_VARIANT_TYPE_STRING },
   { "copyright_holder", G_VARIANT_TYPE_STRING },
   { "discovery_feed_content", G_VARIANT_TYPE_VARDICT },
-  { "ekn_id", G_VARIANT_TYPE_STRING },
+  { "id", G_VARIANT_TYPE_STRING },
   { "language", G_VARIANT_TYPE_STRING },
   { "last_modified_date", G_VARIANT_TYPE_STRING },
   { "license", G_VARIANT_TYPE_STRING },

--- a/search-provider/eks-search-provider.c
+++ b/search-provider/eks-search-provider.c
@@ -31,7 +31,7 @@ struct _EksSearchProvider
   EksSearchProvider2 *skeleton;
   EksKnowledgeSearch *app_proxy;
   GCancellable *cancellable;
-  // Hash table with ekn id string keys, DmContent values
+  // Hash table with ID string keys, DmContent values
   GHashTable *object_cache;
 };
 
@@ -193,10 +193,11 @@ search_finished (GObject *source,
   for (GSList *l = models; l; l = l->next)
     {
       DmContent *model = l->data;
-      g_autofree gchar *ekn_id = NULL;
-      g_object_get (model, "ekn-id", &ekn_id, NULL);
-      g_hash_table_insert (state->self->object_cache, g_strdup (ekn_id), g_object_ref (model));
-      g_variant_builder_add (&builder, "s", ekn_id);
+      g_autofree char *id = NULL;
+      g_object_get (model, "id", &id, NULL);
+      g_hash_table_insert (state->self->object_cache, g_strdup (id),
+                           g_object_ref (model));
+      g_variant_builder_add (&builder, "s", id);
     }
   g_dbus_method_invocation_return_value (state->invocation, g_variant_new ("(as)", &builder));
   search_state_free (state);


### PR DESCRIPTION
This also changes the API of the Results return value in the content
metadata provider interface.

https://phabricator.endlessm.com/T22103