### PR TITLE
manifest: Make sure to explicitly --own-name=com.endlessm.EknServices…

### DIFF
--- a/com.endlessm.EknServices.json.in
+++ b/com.endlessm.EknServices.json.in
@@ -10,6 +10,7 @@
         "--filesystem=~/.local/share/flatpak:ro",
         "--filesystem=~/.local/share",
         "--env=EKN_SUBSCRIPTIONS_DIR=.local/share/com.endlessm.subscriptions",
+        "--own-name=com.endlessm.EknServices.SearchProviderV1",
         "--share=network",
         "--socket=session-bus"
     ],

--- a/search-provider/com.endlessm.EknServices.SearchProviderV1.service.in
+++ b/search-provider/com.endlessm.EknServices.SearchProviderV1.service.in
@@ -1,4 +1,4 @@
 [D-BUS Service]
 Name=com.endlessm.EknServices.SearchProviderV1
 Exec=%bindir%/eks-search-provider-v1
-X-Flatpak-RunOptions=no-a11y-bus
+X-Flatpak-RunOptions=no-a11y-bus;no-documents-portal

--- a/search-provider/com.endlessm.EknServices.SearchProviderV1.service.in
+++ b/search-provider/com.endlessm.EknServices.SearchProviderV1.service.in
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.endlessm.EknServices.SearchProviderV1
 Exec=%bindir%/eks-search-provider-v1
+X-Flatpak-RunOptions=no-a11y-bus


### PR DESCRIPTION
….SearchProviderV1

Technically, flatpak is only supposed to export the .service file
if it matches the app ID exactly, however due to a bug in flatpak
it was only doing prefix matching. If we explictly use --own-name
then with upcoming flatpak changes in https://github.com/flatpak/flatpak/pull/1541
the .service file will exported.

https://phabricator.endlessm.com/T22088