### PR TITLE
Bump up EknServices interface to version 3

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,7 @@ EXTRA_DIST =
 # These files need to be filled in with make variables
 do_subst = $(SED) -e 's|%bindir%|$(bindir)|g'
 subst_files = \
-	search-provider/com.endlessm.EknServices2.SearchProviderV2.service \
+	search-provider/com.endlessm.EknServices3.SearchProviderV3.service \
 	$(NULL)
 
 $(subst_files): %: %.in Makefile
@@ -29,7 +29,7 @@ EXTRA_DIST += $(patsubst %,%.in,$(subst_files))
 # # # DBUS SERVICES # # #
 servicedir = $(datadir)/dbus-1/services
 service_DATA = \
-	search-provider/com.endlessm.EknServices2.SearchProviderV2.service \
+	search-provider/com.endlessm.EknServices3.SearchProviderV3.service \
 	$(NULL)
 
 search-provider/eks-discovery-feed-provider-dbus.h search-provider/eks-discovery-feed-provider-dbus.c: search-provider/eks-discovery-feed-provider-dbus.xml Makefile.am
@@ -82,7 +82,7 @@ BUILT_SOURCES = \
 	search-provider/eks-search-provider-dbus.c \
 	$(NULL)
 
-eks_search_provider_v2_SOURCES = \
+eks_search_provider_v3_SOURCES = \
 	search-provider/eks-discovery-feed-provider.c \
 	search-provider/eks-discovery-feed-provider.h \
 	search-provider/eks-discovery-feed-provider-dbus.c \
@@ -109,18 +109,18 @@ eks_search_provider_v2_SOURCES = \
 	search-provider/eks-subtree-dispatcher.c \
 	search-provider/eks-subtree-dispatcher.h \
 	$(NULL)
-eks_search_provider_v2_CFLAGS = \
+eks_search_provider_v3_CFLAGS = \
 	@SEARCH_PROVIDER_CFLAGS@ \
 	-I $(builddir)/search-provider \
 	$(AM_CFLAGS) \
 	$(NULL)
-eks_search_provider_v2_LDADD = \
+eks_search_provider_v3_LDADD = \
 	@SEARCH_PROVIDER_LIBS@ \
 	$(NULL)
 
 # # # BINARIES # # #
 bin_PROGRAMS += \
-	eks-search-provider-v2 \
+	eks-search-provider-v3 \
 	$(NULL)
 
 -include $(top_srcdir)/git.mk

--- a/com.endlessm.EknServices.json.in
+++ b/com.endlessm.EknServices.json.in
@@ -1,5 +1,5 @@
 {
-    "app-id": "com.endlessm.EknServices2",
+    "app-id": "com.endlessm.EknServices3",
     "branch": "master",
     "runtime": "com.endlessm.apps.Platform",
     "runtime-version": "master",
@@ -12,8 +12,8 @@
         "--socket=session-bus"
     ],
     "add-extensions": {
-        "com.endlessm.EknServices2.Extension": {
-            "directory": "build/eos-knowledge-services/2",
+        "com.endlessm.EknServices3.Extension": {
+            "directory": "build/eos-knowledge-services/3",
             "bundle": true,
             "autodelete": true,
             "no-autodownload": true
@@ -34,10 +34,10 @@
             "name": "eos-knowledge-services-extension",
             "buildsystem": "simple",
             "build-commands": [
-                "mkdir -p /app/build/eos-knowledge-services/2",
-                "cp -r /app/bin /app/build/eos-knowledge-services/2",
-                "cp -r /app/lib /app/build/eos-knowledge-services/2",
-                "cp -r /app/share /app/build/eos-knowledge-services/2"
+                "mkdir -p /app/build/eos-knowledge-services/3",
+                "cp -r /app/bin /app/build/eos-knowledge-services/3",
+                "cp -r /app/lib /app/build/eos-knowledge-services/3",
+                "cp -r /app/share /app/build/eos-knowledge-services/3"
             ]
         }
     ]

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 # --------------
 # Initialize Autoconf: package name, version, bug report address, tarball name,
 # website
-AC_INIT([Endless OS Knowledge Services], [2],
+AC_INIT([Endless OS Knowledge Services], [3],
     [], [eos-knowledge-services], [http://endlessm.com])
 # Initialize Automake: enable all warnings and do not insist on GNU standards
 # no-portability suppresses warnings about syntax specific to GNU make

--- a/search-provider/com.endlessm.EknServices2.SearchProviderV2.service.in
+++ b/search-provider/com.endlessm.EknServices2.SearchProviderV2.service.in
@@ -1,3 +1,0 @@
-[D-BUS Service]
-Name=com.endlessm.EknServices2.SearchProviderV2
-Exec=%bindir%/eks-search-provider-v2

--- a/search-provider/com.endlessm.EknServices3.SearchProviderV3.service.in
+++ b/search-provider/com.endlessm.EknServices3.SearchProviderV3.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=com.endlessm.EknServices3.SearchProviderV3
+Exec=%bindir%/eks-search-provider-v3

--- a/search-provider/eks-search-main.c
+++ b/search-provider/eks-search-main.c
@@ -7,7 +7,7 @@ main (gint   argc,
       gchar *argv[])
 {
     g_autoptr(GApplication) app = g_object_new (EKS_TYPE_SEARCH_APP,
-                                                "application-id", "com.endlessm.EknServices2.SearchProviderV2",
+                                                "application-id", "com.endlessm.EknServices3.SearchProviderV3",
                                                 "flags", G_APPLICATION_IS_SERVICE,
                                                 "inactivity-timeout", 12000,
                                                 NULL);


### PR DESCRIPTION
We changed the dependencies and the on disk file format for the
database, so we need to bump the API version of the service.

https://phabricator.endlessm.com/T22061