### PR TITLE
manifest: Make sure to explicitly --own-name=com.endlessm.EknServices3.SearchProviderV3

### DIFF
--- a/com.endlessm.EknServices.json.in
+++ b/com.endlessm.EknServices.json.in
@@ -8,6 +8,7 @@
         "--filesystem=/var/lib/flatpak:ro",
         "--filesystem=/var/endless-extra/flatpak:ro",
         "--filesystem=~/.local/share/flatpak:ro",
+        "--own-name=com.endlessm.EknServices3.SearchProviderV3",
         "--share=network",
         "--socket=session-bus"
     ],

--- a/search-provider/com.endlessm.EknServices3.SearchProviderV3.service.in
+++ b/search-provider/com.endlessm.EknServices3.SearchProviderV3.service.in
@@ -1,4 +1,4 @@
 [D-BUS Service]
 Name=com.endlessm.EknServices3.SearchProviderV3
 Exec=%bindir%/eks-search-provider-v3
-X-Flatpak-RunOptions=no-a11y-bus
+X-Flatpak-RunOptions=no-a11y-bus;no-documents-portal

--- a/search-provider/com.endlessm.EknServices3.SearchProviderV3.service.in
+++ b/search-provider/com.endlessm.EknServices3.SearchProviderV3.service.in
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.endlessm.EknServices3.SearchProviderV3
 Exec=%bindir%/eks-search-provider-v3
+X-Flatpak-RunOptions=no-a11y-bus


### PR DESCRIPTION
Technically, flatpak is only supposed to export the .service file
if it matches the app ID exactly, however due to a bug in flatpak
it was only doing prefix matching. If we explictly use --own-name
then with upcoming flatpak changes in flatpak/flatpak#1541
the .service file will exported.

https://phabricator.endlessm.com/T22088