### PR TITLE
V2: search-provider: Allocate one more slot in shards strv and set it to zero

### DIFF
--- a/search-provider/eks-query-util.c
+++ b/search-provider/eks-query-util.c
@@ -74,7 +74,7 @@ models_and_shards_for_result (EkncEngine    *engine,
 GStrv
 strv_from_shard_list (GSList *string_list)
 {
-  GStrv strv = g_new0 (char *, g_slist_length (string_list));
+  GStrv strv = g_new0 (char *, g_slist_length (string_list) + 1);
   guint count = 0;
 
   for (GSList *l = string_list; l; l = l->next)


### PR DESCRIPTION
Otherwise the strv never has a null terminator, which causes
gvariant serialization to crash later.

https://phabricator.endlessm.com/T22518