### PR TITLE
feed: Pass NULL as sentinel

### DIFF
--- a/search-provider/eks-discovery-feed-provider.c
+++ b/search-provider/eks-discovery-feed-provider.c
@@ -536,7 +536,7 @@ static gboolean
 model_has_thumbnail_uri (EkncContentObjectModel *model)
 {
   g_autofree char *thumbnail_uri = NULL;
-  g_object_get (model, "thumbnail-uri", &thumbnail_uri);
+  g_object_get (model, "thumbnail-uri", &thumbnail_uri, NULL);
 
   return thumbnail_uri != NULL;
 }


### PR DESCRIPTION
Otherwise we'll crash when trying to read later properties.

https://phabricator.endlessm.com/T22597