### PR TITLE
feed: Bump video query limit to G_MAXUINT

### DIFF
--- a/search-provider/eks-discovery-feed-provider.c
+++ b/search-provider/eks-discovery-feed-provider.c
@@ -18,7 +18,7 @@
 #define NUMBER_OF_ARTICLES 5
 #define DAYS_IN_YEAR 365
 // In SDK2, the default limit is 0 in SDK3, the default limit is all matches
-#define SENSIBLE_QUERY_LIMIT 500
+#define SENSIBLE_QUERY_LIMIT G_MAXUINT
 
 struct _EksDiscoveryFeedProvider
 {


### PR DESCRIPTION
This is the default on SDK3, but the default on SDK2 is 0, so
override it.

https://phabricator.endlessm.com/T22923