### PR TITLE
feed: Bump video query limit to G_MAXUINT

### DIFF
--- a/search-provider/eks-discovery-feed-provider.c
+++ b/search-provider/eks-discovery-feed-provider.c
@@ -17,9 +17,9 @@
 
 #define NUMBER_OF_ARTICLES 5
 #define DAYS_IN_YEAR 365
-#define SENSIBLE_QUERY_LIMIT 500
+#define SENSIBLE_QUERY_LIMIT G_MAXUINT
 
-struct _EksDiscoveryFeedDatabaseContentProvider
+struct _EksDiscoveryFeedProvider
 {
   GObject parent_instance;
 


### PR DESCRIPTION
The default is 0 and querying anything less than the maximum
with the current query approach runs the risk of missing content,
so bump it to G_MAXUINT

https://phabricator.endlessm.com/T22923