### PR TITLE
metadata-provider: Set array clear func to g_value_unset

### DIFF
--- a/search-provider/eks-metadata-provider.c
+++ b/search-provider/eks-metadata-provider.c
@@ -571,6 +571,8 @@ create_query_from_dbus_query_parameters (GVariant     *query_parameters,
   GVariant *iter_value;
 
   g_autoptr(GArray) values_array = g_array_new (FALSE, TRUE, sizeof (GValue));
+  g_array_set_clear_func (values_array, (GDestroyNotify) g_value_unset);
+
   g_autoptr(GPtrArray) props_array = g_ptr_array_new_with_free_func (g_free);
 
   /* Always add the app-id to the query */


### PR DESCRIPTION
Otherwise all the constructed GValues are never unset, leaking
their contents.

https://phabricator.endlessm.com/T22964