### PR TITLE
Add EknServices4 with SDK 6 support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,7 @@ EXTRA_DIST =
 # These files need to be filled in with make variables
 do_subst = $(SED) -e 's|%bindir%|$(bindir)|g'
 subst_files = \
-	search-provider/com.endlessm.EknServices3.SearchProviderV3.service \
+	search-provider/com.endlessm.EknServices4.SearchProviderV4.service \
 	$(NULL)
 
 $(subst_files): %: %.in Makefile
@@ -29,7 +29,7 @@ EXTRA_DIST += $(patsubst %,%.in,$(subst_files))
 # # # DBUS SERVICES # # #
 servicedir = $(datadir)/dbus-1/services
 service_DATA = \
-	search-provider/com.endlessm.EknServices3.SearchProviderV3.service \
+	search-provider/com.endlessm.EknServices4.SearchProviderV4.service \
 	$(NULL)
 
 search-provider/eks-discovery-feed-provider-dbus.h search-provider/eks-discovery-feed-provider-dbus.c: search-provider/eks-discovery-feed-provider-dbus.xml Makefile.am
@@ -82,7 +82,7 @@ BUILT_SOURCES = \
 	search-provider/eks-search-provider-dbus.c \
 	$(NULL)
 
-eks_search_provider_v3_SOURCES = \
+eks_search_provider_v4_SOURCES = \
 	search-provider/eks-discovery-feed-provider.c \
 	search-provider/eks-discovery-feed-provider.h \
 	search-provider/eks-discovery-feed-provider-dbus.c \
@@ -109,18 +109,18 @@ eks_search_provider_v3_SOURCES = \
 	search-provider/eks-subtree-dispatcher.c \
 	search-provider/eks-subtree-dispatcher.h \
 	$(NULL)
-eks_search_provider_v3_CFLAGS = \
+eks_search_provider_v4_CFLAGS = \
 	@SEARCH_PROVIDER_CFLAGS@ \
 	-I $(builddir)/search-provider \
 	$(AM_CFLAGS) \
 	$(NULL)
-eks_search_provider_v3_LDADD = \
+eks_search_provider_v4_LDADD = \
 	@SEARCH_PROVIDER_LIBS@ \
 	$(NULL)
 
 # # # BINARIES # # #
 bin_PROGRAMS += \
-	eks-search-provider-v3 \
+	eks-search-provider-v4 \
 	$(NULL)
 
 -include $(top_srcdir)/git.mk

--- a/build-flatpak.sh
+++ b/build-flatpak.sh
@@ -6,7 +6,7 @@ rm -rf files var metadata export build
 BRANCH=${BRANCH:-master}
 GIT_CLONE_BRANCH=${GIT_CLONE_BRANCH:-HEAD}
 RUN_TESTS=${RUN_TESTS:-false}
-PROJECT=${PROJECT:-com.endlessm.EknServices3}
+PROJECT=${PROJECT:-com.endlessm.EknServices4}
 
 sed \
   -e "s|@BRANCH@|${BRANCH}|g" \

--- a/com.endlessm.EknServices.json.in
+++ b/com.endlessm.EknServices.json.in
@@ -1,5 +1,5 @@
 {
-    "app-id": "com.endlessm.EknServices3",
+    "app-id": "com.endlessm.EknServices4",
     "branch": "master",
     "runtime": "com.endlessm.apps.Platform",
     "runtime-version": "master",
@@ -8,13 +8,13 @@
         "--filesystem=/var/lib/flatpak:ro",
         "--filesystem=/var/endless-extra/flatpak:ro",
         "--filesystem=~/.local/share/flatpak:ro",
-        "--own-name=com.endlessm.EknServices3.SearchProviderV3",
+        "--own-name=com.endlessm.EknServices4.SearchProviderV4",
         "--share=network",
         "--socket=session-bus"
     ],
     "add-extensions": {
-        "com.endlessm.EknServices3.Extension": {
-            "directory": "build/eos-knowledge-services/3",
+        "com.endlessm.EknServices4.Extension": {
+            "directory": "build/eos-knowledge-services/4",
             "bundle": true,
             "autodelete": true,
             "no-autodownload": true
@@ -35,10 +35,10 @@
             "name": "eos-knowledge-services-extension",
             "buildsystem": "simple",
             "build-commands": [
-                "mkdir -p /app/build/eos-knowledge-services/3",
-                "cp -r /app/bin /app/build/eos-knowledge-services/3",
-                "cp -r /app/lib /app/build/eos-knowledge-services/3",
-                "cp -r /app/share /app/build/eos-knowledge-services/3"
+                "mkdir -p /app/build/eos-knowledge-services/4",
+                "cp -r /app/bin /app/build/eos-knowledge-services/4",
+                "cp -r /app/lib /app/build/eos-knowledge-services/4",
+                "cp -r /app/share /app/build/eos-knowledge-services/4"
             ]
         }
     ]

--- a/docs/DiscoveryFeedProvider.md
+++ b/docs/DiscoveryFeedProvider.md
@@ -76,6 +76,7 @@ depending on the SDK version in use:
 | 2           | EknServices2 | SearchProviderV2    |
 | 3           | EknServices2 | SearchProviderV2    |
 | 4           | EknServices3 | SearchProviderV3    |
+| 6           | EknServices4 | SearchProviderV4    |
 
 The `[encoded_app_id]` is encoded according to the systemd D-Bus object name
 encoding scheme.

--- a/search-provider/com.endlessm.EknServices3.SearchProviderV3.service.in
+++ b/search-provider/com.endlessm.EknServices3.SearchProviderV3.service.in
@@ -1,4 +1,0 @@
-[D-BUS Service]
-Name=com.endlessm.EknServices3.SearchProviderV3
-Exec=%bindir%/eks-search-provider-v3
-X-Flatpak-RunOptions=no-a11y-bus;no-documents-portal

--- a/search-provider/com.endlessm.EknServices4.SearchProviderV4.service.in
+++ b/search-provider/com.endlessm.EknServices4.SearchProviderV4.service.in
@@ -1,0 +1,4 @@
+[D-BUS Service]
+Name=com.endlessm.EknServices4.SearchProviderV4
+Exec=%bindir%/eks-search-provider-v4
+X-Flatpak-RunOptions=no-a11y-bus;no-documents-portal

--- a/search-provider/eks-search-main.c
+++ b/search-provider/eks-search-main.c
@@ -7,7 +7,7 @@ main (gint   argc,
       gchar *argv[])
 {
     g_autoptr(GApplication) app = g_object_new (EKS_TYPE_SEARCH_APP,
-                                                "application-id", "com.endlessm.EknServices3.SearchProviderV3",
+                                                "application-id", "com.endlessm.EknServices4.SearchProviderV4",
                                                 "flags", G_APPLICATION_IS_SERVICE,
                                                 "inactivity-timeout", 12000,
                                                 NULL);


### PR DESCRIPTION
This change will allow us to make any changes we need to SDK 6 without
breaking existing SDK 4 and SDK 5 apps. In addition, we can prevent a
situation where an SDK 6 app could be searched by an incompatible search
provider.
    
https://phabricator.endlessm.com/T29688
