### PR TITLE
Revert "Add permission to read from /run/flatpak"

### DIFF
--- a/com.endlessm.EknServices.json.in
+++ b/com.endlessm.EknServices.json.in
@@ -5,7 +5,6 @@
     "runtime-version": "master",
     "sdk": "com.endlessm.apps.Sdk",
     "finish-args": [
-        "--filesystem=/run/flatpak:ro",
         "--filesystem=/var/lib/flatpak:ro",
         "--filesystem=/var/endless-extra/flatpak:ro",
         "--filesystem=~/.local/share/flatpak:ro",


### PR DESCRIPTION
This reverts commit f63ac9b155855bb8c27b11be07cd62664e013ce4.

Flatpak 1.12 attempts to bind-mount stuff into /run/flatpak, since
https://github.com/flatpak/flatpak/commit/40510e8ae8fd433df04959938b8e81e582849481,
which interacts poorly with this sandbox hole and prevents the app from
starting.

The sandbox hole is no longer needed because we no longer ship USB keys
where encyclopedia content is stored outside the Endless OS filesystem.
If we did want to restore support for this in future, I believe it would
be sufficient to use '--filesystem=/run/flatpak/extensions' instead.

https://phabricator.endlessm.com/T33181
